### PR TITLE
Changed geojson to match specification

### DIFF
--- a/.construction_tools/revised_EMSC_region_data/attr_IDs.json
+++ b/.construction_tools/revised_EMSC_region_data/attr_IDs.json
@@ -1,1 +1,1 @@
-{"https://www.seismicportal.eu/feregions.html\nhttps://www.seismicportal.eu/fe_regions_ws/query": "tqNt"}
+{"https://www.seismicportal.eu/feregions.html\nhttps://www.seismicportal.eu/fe_regions_ws/query": "ZXgA"}


### PR DESCRIPTION
This set now properly follows the GeoJSON [Specification](https://tools.ietf.org/html/rfc7946). Google Earth is able to view it without issue including each regions properties field