### PR TITLE
- seedlink servers invisible bug fix

### DIFF
--- a/GlobalQuakeCore/src/main/java/globalquake/ui/table/TableCellRendererAdapter.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/table/TableCellRendererAdapter.java
@@ -34,7 +34,7 @@ public class TableCellRendererAdapter<E, T> extends DefaultTableCellRenderer {
                     setBackground(bck);
                 }
                 //sets the background color if selected or not
-                setForeground(isSelected ? Color.WHITE : Color.BLACK);
+                setForeground(isSelected ? Color.BLACK : Color.BLACK);
                 setText(getText(entity, t));
             }
 

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/table/TableCellRendererAdapter.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/table/TableCellRendererAdapter.java
@@ -33,7 +33,8 @@ public class TableCellRendererAdapter<E, T> extends DefaultTableCellRenderer {
                 if (bck != null) {
                     setBackground(bck);
                 }
-                setForeground(getForeground(entity, t));
+                //sets the background color if selected or not
+                setForeground(isSelected ? Color.WHITE : Color.BLACK);
                 setText(getText(entity, t));
             }
 


### PR DESCRIPTION
issue only seen on macs

- the issue when highlighting specific servers in the station database monitor was it set the text for all highlighted and non highlighted cells to white. meaning the text for non selected cells was invisible since the background is white. I just made the text remain unchanged as black for both windows and mac.

BEFORE:
<img width="997" alt="Screenshot 2024-02-03 at 10 15 37 PM" src="https://github.com/xspanger3770/GlobalQuake/assets/156865868/8ca04292-7fc3-45e9-bf04-aa7227b2c312">

AFTER:

<img width="997" alt="Screenshot 2024-02-05 at 9 45 34 AM" src="https://github.com/xspanger3770/GlobalQuake/assets/156865868/568ec8a5-5747-40d7-8506-985ce850fecb">

