### PR TITLE
- settings multiple instances ghost windows fix NEW

### DIFF
--- a/GlobalQuakeClient/src/main/java/globalquake/ui/client/MainFrame.java
+++ b/GlobalQuakeClient/src/main/java/globalquake/ui/client/MainFrame.java
@@ -149,6 +149,8 @@ public class MainFrame extends GQFrame {
                 // If not, create a new instance and make it visible
                 SettingsFrame settingsFrame = new SettingsFrame(MainFrame.this, GlobalQuakeClient.instance != null);
                 settingsFrame.setVisible(true);
+                // Ensure that the SettingsFrame is always on top
+				settingsFrame.setAlwaysOnTop(true);
             }
     });
     

--- a/GlobalQuakeClient/src/main/java/globalquake/ui/client/MainFrame.java
+++ b/GlobalQuakeClient/src/main/java/globalquake/ui/client/MainFrame.java
@@ -142,8 +142,16 @@ public class MainFrame extends GQFrame {
         JPanel buttons2 = new JPanel(grid2);
 
         JButton settingsButton = new JButton("Settings");
-        settingsButton.addActionListener(actionEvent -> new SettingsFrame(MainFrame.this, GlobalQuakeClient.instance != null).setVisible(true));
-
+        // Listener for settings panel button
+        settingsButton.addActionListener(actionEvent -> {
+            // Check if an instance of SettingsFrame already exists
+            if (SettingsFrame.getInstance() == null) {
+                // If not, create a new instance and make it visible
+                SettingsFrame settingsFrame = new SettingsFrame(MainFrame.this, GlobalQuakeClient.instance != null);
+                settingsFrame.setVisible(true);
+            }
+    });
+    
         buttons2.add(settingsButton);
 
         JButton exitButton = new JButton("Exit");

--- a/GlobalQuakeClient/src/main/java/globalquake/ui/globalquake/GlobalQuakeFrame.java
+++ b/GlobalQuakeClient/src/main/java/globalquake/ui/globalquake/GlobalQuakeFrame.java
@@ -119,7 +119,14 @@ public class GlobalQuakeFrame extends GQFrame {
 		settings.addActionListener(new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent actionEvent) {
-				new SettingsFrame(GlobalQuakeFrame.this, GlobalQuakeClient.instance != null).setVisible(true);
+				 // Check if an instance of SettingsFrame already exists
+				 if (SettingsFrame.getInstance() == null) {
+					// If not, create a new instance and make it visible
+					SettingsFrame settingsFrame = new SettingsFrame(GlobalQuakeFrame.this, GlobalQuakeClient.instance != null);
+					settingsFrame.setVisible(true);
+					// Ensure that the SettingsFrame is always on top
+					settingsFrame.setAlwaysOnTop(true);
+				}
 			}
 		});
 

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/settings/SettingsFrame.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/settings/SettingsFrame.java
@@ -14,6 +14,9 @@ import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
 public class SettingsFrame extends GQFrame {
 
 	private final List<SettingsPanel> panels = new LinkedList<>();
@@ -45,7 +48,21 @@ public class SettingsFrame extends GQFrame {
         }
         openInstance = this;
         initialize(parent);
+
+		 // Add a window listener to set openInstance to null when the frame is closed
+		 addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                openInstance = null;
+            }
+        });
     }
+
+	// gets the instance of SettingsFrame
+	public static SettingsFrame getInstance() {
+        return openInstance;
+    }
+
 
 	private void initialize(Component parent) {
 		setTitle(!isClient ? "GlobalQuake Settings" : "GlobalQuake Settings (Client)");
@@ -95,6 +112,7 @@ public class SettingsFrame extends GQFrame {
 		setResizable(false);
 		setLocationRelativeTo(parent);
 	}
+
 
 	private void addPanels() {
 		panels.add(new GeneralSettingsPanel(this));


### PR DESCRIPTION
Fixed this issue which resulted in me not knowing you are using separate logic for client side settings button creation vs launcher settings creation. 

BEFORE:

![image-ezgif com-webp-to-jpg-converter](https://github.com/xspanger3770/GlobalQuake/assets/156865868/b4445245-01fe-4cd2-881e-0f4797449612)
