### PR TITLE
Use find_package in CMakeLists to search for JNI

### DIFF
--- a/GQHypocenterSearch/CMakeLists.txt
+++ b/GQHypocenterSearch/CMakeLists.txt
@@ -25,8 +25,9 @@ foreach(arch ${CUDA_ARCH_LIST})
     set(CUDA_NVCC_FLAGS_${arch} "-gencode arch=compute_${arch},code=sm_${arch}")
 endforeach()
 
-include_directories(/usr/lib/jvm/java-17-openjdk-amd64/include/)
-include_directories(/usr/lib/jvm/java-17-openjdk-amd64/include/linux)
+# Find JNI (Java Native Interface)
+find_package(JNI REQUIRED)
+include_directories(${JNI_INCLUDE_DIRS})
 
 # Compile CUDA sources into a shared library
 cuda_add_library(gq_hypocs SHARED ${SRC_FILES})


### PR DESCRIPTION
Instead of hardcoding the JNI path which would only work on Ubuntu, use `find_package` to search for JNI in the user's system regardless of their operating system choice.