### PR TITLE
Memory leak in the FeatureGlobalStation during station intensity formatting to String

### DIFF
--- a/GlobalQuakeClient/src/main/java/globalquake/ui/globalquake/feature/FeatureGlobalStation.java
+++ b/GlobalQuakeClient/src/main/java/globalquake/ui/globalquake/feature/FeatureGlobalStation.java
@@ -20,11 +20,15 @@ import gqserver.api.packets.station.InputType;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import java.awt.*;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Collection;
+import java.util.Locale;
 
 public class FeatureGlobalStation extends RenderFeature<AbstractStation> {
 
     private final Collection<AbstractStation> globalStations;
+    private static final DecimalFormat df = new DecimalFormat("0.0",  new DecimalFormatSymbols(Locale.ENGLISH));
 
     public static final double RATIO_YELLOW = 2000.0;
     public static final double RATIO_RED = 20000.0;
@@ -243,7 +247,7 @@ public class FeatureGlobalStation extends RenderFeature<AbstractStation> {
         }
         if (scroll < Settings.stationIntensityVisibilityZoomLevel || (mouseNearby && scroll < 1)) {
             g.setColor(Color.white);
-            String str = !station.hasDisplayableData() ? "-.-" : "%.1f".formatted(station.getMaxRatio60S());
+            String str = !station.hasDisplayableData() ? "-.-" : df.format(station.getMaxRatio60S());
             g.setFont(new Font("Calibri", Font.PLAIN, 13));
             g.setColor(station.getAnalysis().getStatus() == AnalysisStatus.EVENT ? Color.green : Color.LIGHT_GRAY);
             if(centerPoint == null) {


### PR DESCRIPTION
One of the memory leaks can be easily fixed by replacing String.formatted with DecimalFormat.format.
![Screenshot 2024-04-28 111849](https://github.com/xspanger3770/GlobalQuake/assets/3225778/d72a5f6f-4315-4f6b-ae0f-a431598bcd06)
