### PR TITLE
Memory leak in the FeatureShakemap

### DIFF
--- a/GlobalQuakeClient/src/main/java/globalquake/ui/globalquake/feature/FeatureShakemap.java
+++ b/GlobalQuakeClient/src/main/java/globalquake/ui/globalquake/feature/FeatureShakemap.java
@@ -154,16 +154,14 @@ public class FeatureShakemap extends RenderFeature<IntensityHex> {
             return;
         }
 
-        Color col = level.getColor();
-
         graphics.setStroke(new BasicStroke(1.0f));
-        graphics.setColor(new Color(col.getRed(), col.getGreen(), col.getBlue(), 100));
+        graphics.setColor(level.getColorAlpha100());
         graphics.fill(elementHex.getShape());
 
         boolean mouseNearby = renderer.getLastMouse() != null && renderer.hasMouseMovedRecently() && elementHex.getShape().contains(renderer.getLastMouse());
 
         if (mouseNearby && renderProperties.scroll < 0.2) {
-            graphics.setColor(col);
+            graphics.setColor(level.getColor());
             graphics.setStroke(new BasicStroke(0.5f));
             graphics.draw(elementHex.getShape());
 

--- a/GlobalQuakeCore/src/main/java/globalquake/core/intensity/Level.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/core/intensity/Level.java
@@ -7,6 +7,7 @@ public final class Level {
     private final String suffix;
     private final double pga;
     private final Color color;
+    private final Color colorAlpha100;
     private final String fullName;
 
     public Level(String name, String suffix, double pga, Color color) {
@@ -14,6 +15,7 @@ public final class Level {
         this.suffix = suffix;
         this.pga = pga;
         this.color = color;
+        this.colorAlpha100 = (new Color(color.getRed(), color.getGreen(), color.getBlue(), 100));
         this.fullName = "%s%s".formatted(getName(), getSuffix());
     }
 
@@ -27,6 +29,10 @@ public final class Level {
 
     public Color getColor() {
         return color;
+    }
+
+    public Color getColorAlpha100() {
+        return colorAlpha100;
     }
 
     public double getPga() {


### PR DESCRIPTION
Every time the render method is executed new Color object is created for the intensity. New constant Colors are created for the Level class to improve the memory leak issue.
![Screenshot 2024-04-28 113014](https://github.com/xspanger3770/GlobalQuake/assets/3225778/3a375c60-5be2-405f-89d0-c528127d3487)
