### PR TITLE
Add Ntfy and Pushover to GQServer

### DIFF
--- a/GlobalQuakeCore/src/main/java/globalquake/core/Settings.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/core/Settings.java
@@ -199,6 +199,8 @@ public final class Settings {
     public static Integer pushoverNearbyShakingPriorityList;
     public static Integer pushoverLightShakingPriorityList;
     public static Integer pushoverStrongShakingPriorityList;
+    public static Boolean ntfySendRevisions;
+    public static Boolean pushoverSendRevisions;
 
     static {
         load();
@@ -366,6 +368,8 @@ public final class Settings {
         loadProperty("pushoverNearbyShakingPriorityList", "-1");
         loadProperty("pushoverLightShakingPriorityList", "0");
         loadProperty("pushoverStrongShakingPriorityList", "1");
+        loadProperty("ntfySendRevisions", "false");
+        loadProperty("pushoverSendRevisions", "false");
     }
 
     private static void runUpdateService() throws IOException {

--- a/GlobalQuakeCore/src/main/java/globalquake/core/Settings.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/core/Settings.java
@@ -179,6 +179,26 @@ public final class Settings {
     public static Boolean antialiasingClusters;
     @SuppressWarnings("unused")
     public static Boolean debugSendPGV;
+    // Pushover and Ntfy settings
+    public static String ntfy;
+    public static String pushoverUserID;
+    public static String pushoverToken;
+    public static Boolean useNtfy;
+    public static Boolean usePushover;
+    public static String pushoverSoundDetected;
+    public static String pushoverSoundFeltLight;
+    public static String pushoverSoundFeltStrong;
+    public static Boolean usePushoverCustomSounds;
+    public static Boolean ntfyNearbyShaking;
+    public static Boolean ntfyFeltShaking;
+    public static Integer ntfyNearbyShakingPriorityList;
+    public static Integer ntfyLightShakingPriorityList;
+    public static Integer ntfyStrongShakingPriorityList;
+    public static Boolean pushoverNearbyShaking;
+    public static Boolean pushoverFeltShaking;
+    public static Integer pushoverNearbyShakingPriorityList;
+    public static Integer pushoverLightShakingPriorityList;
+    public static Integer pushoverStrongShakingPriorityList;
 
     static {
         load();
@@ -327,6 +347,25 @@ public final class Settings {
         loadProperty("oldEventsMagnitudeFilterEnabled", "false");
         loadProperty("oldEventsMagnitudeFilter", "4.0", o -> validateDouble(0, 10, (Double) o));
         loadProperty("oldEventsOpacity", "100.0", o -> validateDouble(0, 100, (Double) o));
+        loadProperty("useNtfy", "false");
+        loadProperty("usePushover", "false");
+        loadProperty("ntfy", "");
+        loadProperty("pushoverUserID", "");
+        loadProperty("pushoverToken", "");
+        loadProperty("pushoverSoundDetected", "");
+        loadProperty("pushoverSoundFeltLight", "");
+        loadProperty("pushoverSoundFeltStrong", "");
+        loadProperty("usePushoverCustomSounds", "false");
+        loadProperty("ntfyNearbyShaking", "false");
+        loadProperty("ntfyFeltShaking", "false");
+        loadProperty("ntfyNearbyShakingPriorityList", "2");
+        loadProperty("ntfyLightShakingPriorityList", "4");
+        loadProperty("ntfyStrongShakingPriorityList", "5");
+        loadProperty("pushoverNearbyShaking", "false");
+        loadProperty("pushoverFeltShaking", "false");
+        loadProperty("pushoverNearbyShakingPriorityList", "-1");
+        loadProperty("pushoverLightShakingPriorityList", "0");
+        loadProperty("pushoverStrongShakingPriorityList", "1");
     }
 
     private static void runUpdateService() throws IOException {

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
@@ -486,7 +486,7 @@ public class AlertSettingsPanel extends SettingsPanel {
         chkBoxPushoverNearbyShaking.addChangeListener(changeEvent -> chkBoxPushoverSendRevisions.setEnabled(chkBoxPushoverNearbyShaking.isSelected()));
         chkBoxPushoverFeltShaking = new JCheckBox("Notify when shaking is expected", Settings.pushoverFeltShaking);
 
-        JPanel pushoverShakingPanel = new JPanel(new GridLayout(3, 1));
+        JPanel pushoverShakingPanel = new JPanel(new GridLayout(4, 1));
         pushoverShakingPanel.setBorder(BorderFactory.createTitledBorder("Shaking Alerts"));
 
         JPanel pushoverNearbyShakingPanel = new JPanel();
@@ -506,6 +506,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         pushoverFeltShakingPanel.add(chkBoxPushoverFeltShaking);
 
         pushoverShakingPanel.add(pushoverFeltShakingPanel);
+
+        JPanel pushoverShakingMessagePanel = new JPanel();
+        pushoverShakingMessagePanel.setLayout(new BoxLayout(pushoverShakingMessagePanel, BoxLayout.X_AXIS));
+        pushoverShakingMessagePanel.add(new JLabel("Enable Earthquake Reports in Debug Settings to receive Final Reports"));
+
+        pushoverShakingPanel.add(pushoverShakingMessagePanel);
 
         panel.add(pushoverShakingPanel);
 

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
@@ -48,6 +48,8 @@ public class AlertSettingsPanel extends SettingsPanel {
     private JComboBox<Integer> pushoverNearbyShakingPriorityListJComboBox;
     private JComboBox<Integer> pushoverLightShakingPriorityListJComboBox;
     private JComboBox<Integer> pushoverStrongShakingPriorityListJComboBox;
+    private JCheckBox chkBoxNtfySendRevisions;
+    private JCheckBox chkBoxPushoverSendRevisions;
 
 
     public AlertSettingsPanel() {
@@ -300,9 +302,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         panel.add(ntfyPanel);
 
         chkBoxNtfyNearbyShaking = new JCheckBox("Notify when nearby shaking is detected", Settings.ntfyNearbyShaking);
+        chkBoxNtfySendRevisions = new JCheckBox("Notify every revision update for nearby shaking", Settings.ntfySendRevisions);
+        chkBoxNtfySendRevisions.setEnabled(chkBoxNtfyNearbyShaking.isSelected());
+        chkBoxNtfyNearbyShaking.addChangeListener(changeEvent -> chkBoxNtfySendRevisions.setEnabled(chkBoxNtfyNearbyShaking.isSelected()));
         chkBoxNtfyFeltShaking = new JCheckBox("Notify when shaking is expected", Settings.ntfyFeltShaking);
 
-        JPanel ntfyShakingPanel = new JPanel(new GridLayout(2, 1));
+        JPanel ntfyShakingPanel = new JPanel(new GridLayout(3, 1));
         ntfyShakingPanel.setBorder(BorderFactory.createTitledBorder("Shaking Alerts"));
 
         JPanel ntfyNearbyShakingPanel = new JPanel();
@@ -310,6 +315,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         ntfyNearbyShakingPanel.add(chkBoxNtfyNearbyShaking);
 
         ntfyShakingPanel.add(ntfyNearbyShakingPanel);
+
+        JPanel ntfySendRevisionsPanel = new JPanel();
+        ntfySendRevisionsPanel.setLayout(new BoxLayout(ntfySendRevisionsPanel, BoxLayout.X_AXIS));
+        ntfySendRevisionsPanel.add(chkBoxNtfySendRevisions);
+
+        ntfyShakingPanel.add(ntfySendRevisionsPanel);
 
         JPanel ntfyFeltShakingPanel = new JPanel();
         ntfyFeltShakingPanel.setLayout(new BoxLayout(ntfyFeltShakingPanel, BoxLayout.X_AXIS));
@@ -458,9 +469,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         panel.add(pushoverPanel);
 
         chkBoxPushoverNearbyShaking = new JCheckBox("Notify when nearby shaking is detected", Settings.pushoverNearbyShaking);
+        chkBoxPushoverSendRevisions = new JCheckBox("Notify every revision update for nearby shaking", Settings.pushoverSendRevisions);
+        chkBoxPushoverSendRevisions.setEnabled(chkBoxPushoverNearbyShaking.isSelected());
+        chkBoxPushoverNearbyShaking.addChangeListener(changeEvent -> chkBoxPushoverSendRevisions.setEnabled(chkBoxPushoverNearbyShaking.isSelected()));
         chkBoxPushoverFeltShaking = new JCheckBox("Notify when shaking is expected", Settings.pushoverFeltShaking);
 
-        JPanel pushoverShakingPanel = new JPanel(new GridLayout(2, 1));
+        JPanel pushoverShakingPanel = new JPanel(new GridLayout(3, 1));
         pushoverShakingPanel.setBorder(BorderFactory.createTitledBorder("Shaking Alerts"));
 
         JPanel pushoverNearbyShakingPanel = new JPanel();
@@ -468,6 +482,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         pushoverNearbyShakingPanel.add(chkBoxPushoverNearbyShaking);
 
         pushoverShakingPanel.add(pushoverNearbyShakingPanel);
+
+        JPanel pushoverSendRevision = new JPanel();
+        pushoverSendRevision.setLayout(new BoxLayout(pushoverSendRevision, BoxLayout.X_AXIS));
+        pushoverSendRevision.add(chkBoxPushoverSendRevisions);
+
+        pushoverShakingPanel.add(pushoverSendRevision);
 
         JPanel pushoverFeltShakingPanel = new JPanel();
         pushoverFeltShakingPanel.setLayout(new BoxLayout(pushoverFeltShakingPanel, BoxLayout.X_AXIS));
@@ -673,6 +693,8 @@ public class AlertSettingsPanel extends SettingsPanel {
         Settings.pushoverNearbyShakingPriorityList = (Integer) pushoverNearbyShakingPriorityListJComboBox.getSelectedItem();
         Settings.pushoverLightShakingPriorityList = (Integer) pushoverLightShakingPriorityListJComboBox.getSelectedItem();
         Settings.pushoverStrongShakingPriorityList = (Integer) pushoverStrongShakingPriorityListJComboBox.getSelectedItem();
+        Settings.ntfySendRevisions = chkBoxNtfySendRevisions.isSelected();
+        Settings.pushoverSendRevisions = chkBoxPushoverSendRevisions.isSelected();
     }
 
     @Override

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
@@ -283,7 +283,7 @@ public class AlertSettingsPanel extends SettingsPanel {
         textFieldNtfy.setEnabled(chkBoxNtfy.isSelected());
         chkBoxNtfy.addChangeListener(changeEvent -> textFieldNtfy.setEnabled(chkBoxNtfy.isSelected()));
 
-        JPanel ntfyPanel = new JPanel(new GridLayout(2, 1));
+        JPanel ntfyPanel = new JPanel(new GridLayout(3, 1));
         ntfyPanel.setBorder(BorderFactory.createTitledBorder("Ntfy Url"));
 
         JPanel ntfyUseNtfyPanel = new JPanel();
@@ -298,6 +298,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         ntfyUrlPanel.add(textFieldNtfy);
 
         ntfyPanel.add(ntfyUrlPanel);
+
+        JPanel ntfyUrlMessagePanel = new JPanel();
+        ntfyUrlMessagePanel.setLayout(new BoxLayout(ntfyUrlMessagePanel, BoxLayout.X_AXIS));
+        ntfyUrlMessagePanel.add(new JLabel("For multiple urls, separate them with commas"));
+
+        ntfyPanel.add(ntfyUrlMessagePanel);
 
         panel.add(ntfyPanel);
 
@@ -443,7 +449,7 @@ public class AlertSettingsPanel extends SettingsPanel {
             textFieldPushoverToken.setEnabled(chkBoxPushover.isSelected());
         });
 
-        JPanel pushoverPanel = new JPanel(new GridLayout(3, 1));
+        JPanel pushoverPanel = new JPanel(new GridLayout(4, 1));
         pushoverPanel.setBorder(BorderFactory.createTitledBorder("Pushover Credentials"));
 
         JPanel usePushoverPanel = new JPanel();
@@ -465,6 +471,12 @@ public class AlertSettingsPanel extends SettingsPanel {
         pushoverTokenPanel.add(textFieldPushoverToken);
 
         pushoverPanel.add(pushoverTokenPanel);
+
+        JPanel pushoverMessagePanel = new JPanel();
+        pushoverMessagePanel.setLayout(new BoxLayout(pushoverMessagePanel, BoxLayout.X_AXIS));
+        pushoverMessagePanel.add(new JLabel("For multiple users using the same token, separate them with commas"));
+
+        pushoverPanel.add(pushoverMessagePanel);
 
         panel.add(pushoverPanel);
 

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
@@ -29,6 +29,26 @@ public class AlertSettingsPanel extends SettingsPanel {
     private JLabel label2;
     private IntensityScaleSelector eewThreshold;
     private JComboBox<Integer> comboBoxEEWClusterLevel;
+    private JTextField textFieldNtfy;
+    private JTextField textFieldPushoverUserID;
+    private JTextField textFieldPushoverToken;
+    private JCheckBox chkBoxNtfy;
+    private JCheckBox chkBoxPushover;
+    private JCheckBox chkBoxPushoverCustomSounds;
+    private JTextField textFieldPushoverSoundDetected;
+    private JTextField textFieldPushoverSoundFeltLight;
+    private JTextField textFieldPushoverSoundFeltStrong;
+    private JCheckBox chkBoxNtfyNearbyShaking;
+    private JCheckBox chkBoxNtfyFeltShaking;
+    private JComboBox<Integer> ntfyNearbyShakingPriorityListJComboBox;
+    private JComboBox<Integer> ntfyLightShakingPriorityListJComboBox;
+    private JComboBox<Integer> ntfyStrongShakingPriorityListJComboBox;
+    private JCheckBox chkBoxPushoverNearbyShaking;
+    private JCheckBox chkBoxPushoverFeltShaking;
+    private JComboBox<Integer> pushoverNearbyShakingPriorityListJComboBox;
+    private JComboBox<Integer> pushoverLightShakingPriorityListJComboBox;
+    private JComboBox<Integer> pushoverStrongShakingPriorityListJComboBox;
+
 
     public AlertSettingsPanel() {
         setLayout(new BorderLayout());
@@ -37,6 +57,8 @@ public class AlertSettingsPanel extends SettingsPanel {
 
         tabbedPane.addTab("Warnings", createWarningsTab());
         tabbedPane.addTab("Pings", createPingsTab());
+        tabbedPane.addTab("Ntfy", createNtfyTab());
+        tabbedPane.addTab("Pushover", createPushoverTab());
 
         add(tabbedPane, BorderLayout.CENTER);
 
@@ -238,6 +260,355 @@ public class AlertSettingsPanel extends SettingsPanel {
         return panel;
     }
 
+    private Component createNtfyTab() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        panel.add(createNtfySettings());
+
+        fill(panel, 10);
+
+        return panel;
+    }
+
+    private Component createNtfySettings() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createTitledBorder("Ntfy Settings"));
+
+        chkBoxNtfy = new JCheckBox("Use Ntfy", Settings.useNtfy);
+        textFieldNtfy = new JTextField(Settings.ntfy, 12);
+        textFieldNtfy.setEnabled(chkBoxNtfy.isSelected());
+        chkBoxNtfy.addChangeListener(changeEvent -> textFieldNtfy.setEnabled(chkBoxNtfy.isSelected()));
+
+        JPanel ntfyPanel = new JPanel(new GridLayout(2, 1));
+        ntfyPanel.setBorder(BorderFactory.createTitledBorder("Ntfy Url"));
+
+        JPanel ntfyUseNtfyPanel = new JPanel();
+        ntfyUseNtfyPanel.setLayout(new BoxLayout(ntfyUseNtfyPanel, BoxLayout.X_AXIS));
+        ntfyUseNtfyPanel.add(chkBoxNtfy);
+
+        ntfyPanel.add(ntfyUseNtfyPanel);
+
+        JPanel ntfyUrlPanel = new JPanel();
+        ntfyUrlPanel.setLayout(new BoxLayout(ntfyUrlPanel, BoxLayout.X_AXIS));
+        ntfyUrlPanel.add(new JLabel("Ntfy Url: "));
+        ntfyUrlPanel.add(textFieldNtfy);
+
+        ntfyPanel.add(ntfyUrlPanel);
+
+        panel.add(ntfyPanel);
+
+        chkBoxNtfyNearbyShaking = new JCheckBox("Notify when nearby shaking is detected", Settings.ntfyNearbyShaking);
+        chkBoxNtfyFeltShaking = new JCheckBox("Notify when shaking is expected", Settings.ntfyFeltShaking);
+
+        JPanel ntfyShakingPanel = new JPanel(new GridLayout(2, 1));
+        ntfyShakingPanel.setBorder(BorderFactory.createTitledBorder("Shaking Alerts"));
+
+        JPanel ntfyNearbyShakingPanel = new JPanel();
+        ntfyNearbyShakingPanel.setLayout(new BoxLayout(ntfyNearbyShakingPanel, BoxLayout.X_AXIS));
+        ntfyNearbyShakingPanel.add(chkBoxNtfyNearbyShaking);
+
+        ntfyShakingPanel.add(ntfyNearbyShakingPanel);
+
+        JPanel ntfyFeltShakingPanel = new JPanel();
+        ntfyFeltShakingPanel.setLayout(new BoxLayout(ntfyFeltShakingPanel, BoxLayout.X_AXIS));
+        ntfyFeltShakingPanel.add(chkBoxNtfyFeltShaking);
+
+        ntfyShakingPanel.add(ntfyFeltShakingPanel);
+
+        panel.add(ntfyShakingPanel);
+
+        JPanel ntfyPriorityPanel = new JPanel(new GridLayout(3, 1));
+        ntfyPriorityPanel.setBorder(BorderFactory.createTitledBorder("Priority"));
+
+        JPanel ntfyPriorityNearbyShakingPanel = new JPanel();
+        ntfyPriorityNearbyShakingPanel.setLayout(new BoxLayout(ntfyPriorityNearbyShakingPanel, BoxLayout.X_AXIS));
+
+        DefaultComboBoxModel<Integer> model1 = new DefaultComboBoxModel<>(new Integer[]{2, 3, 4, 5});
+        ntfyNearbyShakingPriorityListJComboBox = new JComboBox<>(model1);
+        ntfyNearbyShakingPriorityListJComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value instanceof Integer) {
+                    switch ((Integer) value) {
+                        case 2: value = "Low"; break;
+                        case 3: value = "Normal"; break;
+                        case 4: value = "High"; break;
+                        case 5: value = "Highest"; break;
+                    }
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
+        ntfyNearbyShakingPriorityListJComboBox.setSelectedItem(Settings.ntfyNearbyShakingPriorityList);
+
+        ntfyPriorityNearbyShakingPanel.add(new JLabel("Priority for Nearby Shaking: "));
+        ntfyPriorityNearbyShakingPanel.add(ntfyNearbyShakingPriorityListJComboBox);
+
+        ntfyPriorityPanel.add(ntfyPriorityNearbyShakingPanel);
+
+        JPanel ntfyPriorityLightShakingPanel = new JPanel();
+        ntfyPriorityLightShakingPanel.setLayout(new BoxLayout(ntfyPriorityLightShakingPanel, BoxLayout.X_AXIS));
+
+        DefaultComboBoxModel<Integer> model2 = new DefaultComboBoxModel<>(new Integer[]{2, 3, 4, 5});
+        ntfyLightShakingPriorityListJComboBox = new JComboBox<>(model2);
+        ntfyLightShakingPriorityListJComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value instanceof Integer) {
+                    switch ((Integer) value) {
+                        case 2: value = "Low"; break;
+                        case 3: value = "Normal"; break;
+                        case 4: value = "High"; break;
+                        case 5: value = "Highest"; break;
+                    }
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
+        ntfyLightShakingPriorityListJComboBox.setSelectedItem(Settings.ntfyLightShakingPriorityList);
+
+        ntfyPriorityLightShakingPanel.add(new JLabel("Priority for Light Shaking: "));
+        ntfyPriorityLightShakingPanel.add(ntfyLightShakingPriorityListJComboBox);
+
+        ntfyPriorityPanel.add(ntfyPriorityLightShakingPanel);
+
+        JPanel ntfyPriorityStrongShakingPanel = new JPanel();
+        ntfyPriorityStrongShakingPanel.setLayout(new BoxLayout(ntfyPriorityStrongShakingPanel, BoxLayout.X_AXIS));
+
+        DefaultComboBoxModel<Integer> model3 = new DefaultComboBoxModel<>(new Integer[]{2, 3, 4, 5});
+        ntfyStrongShakingPriorityListJComboBox = new JComboBox<>(model3);
+        ntfyStrongShakingPriorityListJComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value instanceof Integer) {
+                    switch ((Integer) value) {
+                        case 2: value = "Low"; break;
+                        case 3: value = "Normal"; break;
+                        case 4: value = "High"; break;
+                        case 5: value = "Highest"; break;
+                    }
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
+        ntfyStrongShakingPriorityListJComboBox.setSelectedItem(Settings.ntfyStrongShakingPriorityList);
+
+        ntfyPriorityStrongShakingPanel.add(new JLabel("Priority for Strong Shaking: "));
+        ntfyPriorityStrongShakingPanel.add(ntfyStrongShakingPriorityListJComboBox);
+
+        ntfyPriorityPanel.add(ntfyPriorityStrongShakingPanel);
+
+        panel.add(ntfyPriorityPanel);
+
+        return panel;
+    }
+
+    private Component createPushoverTab() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        panel.add(createPushoverSettings());
+
+        fill(panel, 10);
+
+        return panel;
+    }
+
+    private Component createPushoverSettings() {
+        JPanel panel = new JPanel();
+
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createTitledBorder("Pushover Settings"));
+
+        chkBoxPushover = new JCheckBox("Use Pushover", Settings.usePushover);
+        textFieldPushoverUserID = new JTextField(Settings.pushoverUserID, 12);
+        textFieldPushoverUserID.setEnabled(chkBoxPushover.isSelected());
+        textFieldPushoverToken = new JTextField(Settings.pushoverToken, 12);
+        textFieldPushoverToken.setEnabled(chkBoxPushover.isSelected());
+        chkBoxPushover.addChangeListener(changeEvent -> {
+            textFieldPushoverUserID.setEnabled(chkBoxPushover.isSelected());
+            textFieldPushoverToken.setEnabled(chkBoxPushover.isSelected());
+        });
+
+        JPanel pushoverPanel = new JPanel(new GridLayout(3, 1));
+        pushoverPanel.setBorder(BorderFactory.createTitledBorder("Pushover Credentials"));
+
+        JPanel usePushoverPanel = new JPanel();
+        usePushoverPanel.setLayout(new BoxLayout(usePushoverPanel, BoxLayout.X_AXIS));
+        usePushoverPanel.add(chkBoxPushover);
+
+        pushoverPanel.add(usePushoverPanel);
+
+        JPanel pushoverIDPanel = new JPanel();
+        pushoverIDPanel.setLayout(new BoxLayout(pushoverIDPanel, BoxLayout.X_AXIS));
+        pushoverIDPanel.add(new JLabel("User ID: "));
+        pushoverIDPanel.add(textFieldPushoverUserID);
+
+        pushoverPanel.add(pushoverIDPanel);
+
+        JPanel pushoverTokenPanel = new JPanel();
+        pushoverTokenPanel.setLayout(new BoxLayout(pushoverTokenPanel, BoxLayout.X_AXIS));
+        pushoverTokenPanel.add(new JLabel("Token: "));
+        pushoverTokenPanel.add(textFieldPushoverToken);
+
+        pushoverPanel.add(pushoverTokenPanel);
+
+        panel.add(pushoverPanel);
+
+        chkBoxPushoverNearbyShaking = new JCheckBox("Notify when nearby shaking is detected", Settings.pushoverNearbyShaking);
+        chkBoxPushoverFeltShaking = new JCheckBox("Notify when shaking is expected", Settings.pushoverFeltShaking);
+
+        JPanel pushoverShakingPanel = new JPanel(new GridLayout(2, 1));
+        pushoverShakingPanel.setBorder(BorderFactory.createTitledBorder("Shaking Alerts"));
+
+        JPanel pushoverNearbyShakingPanel = new JPanel();
+        pushoverNearbyShakingPanel.setLayout(new BoxLayout(pushoverNearbyShakingPanel, BoxLayout.X_AXIS));
+        pushoverNearbyShakingPanel.add(chkBoxPushoverNearbyShaking);
+
+        pushoverShakingPanel.add(pushoverNearbyShakingPanel);
+
+        JPanel pushoverFeltShakingPanel = new JPanel();
+        pushoverFeltShakingPanel.setLayout(new BoxLayout(pushoverFeltShakingPanel, BoxLayout.X_AXIS));
+        pushoverFeltShakingPanel.add(chkBoxPushoverFeltShaking);
+
+        pushoverShakingPanel.add(pushoverFeltShakingPanel);
+
+        panel.add(pushoverShakingPanel);
+
+        JPanel pushoverPriorityPanel = new JPanel(new GridLayout(3, 1));
+        pushoverPriorityPanel.setBorder(BorderFactory.createTitledBorder("Priority"));
+
+        JPanel pushoverPriorityNearbyShakingPanel = new JPanel();
+        pushoverPriorityNearbyShakingPanel.setLayout(new BoxLayout(pushoverPriorityNearbyShakingPanel, BoxLayout.X_AXIS));
+
+        DefaultComboBoxModel<Integer> model1 = new DefaultComboBoxModel<>(new Integer[]{-1, 0, 1});
+        pushoverNearbyShakingPriorityListJComboBox = new JComboBox<>(model1);
+        pushoverNearbyShakingPriorityListJComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value instanceof Integer) {
+                    switch ((Integer) value) {
+                        case -1: value = "Low"; break;
+                        case 0: value = "Normal"; break;
+                        case 1: value = "High"; break;
+                    }
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
+        pushoverNearbyShakingPriorityListJComboBox.setSelectedItem(Settings.pushoverNearbyShakingPriorityList);
+
+        pushoverPriorityNearbyShakingPanel.add(new JLabel("Priority for Nearby Shaking: "));
+        pushoverPriorityNearbyShakingPanel.add(pushoverNearbyShakingPriorityListJComboBox);
+
+        pushoverPriorityPanel.add(pushoverPriorityNearbyShakingPanel);
+
+        JPanel pushoverPriorityLightShakingPanel = new JPanel();
+        pushoverPriorityLightShakingPanel.setLayout(new BoxLayout(pushoverPriorityLightShakingPanel, BoxLayout.X_AXIS));
+
+        DefaultComboBoxModel<Integer> model2 = new DefaultComboBoxModel<>(new Integer[]{-1, 0, 1});
+
+        pushoverLightShakingPriorityListJComboBox = new JComboBox<>(model2);
+
+        pushoverLightShakingPriorityListJComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value instanceof Integer) {
+                    switch ((Integer) value) {
+                        case -1: value = "Low"; break;
+                        case 0: value = "Normal"; break;
+                        case 1: value = "High"; break;
+                    }
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
+        pushoverLightShakingPriorityListJComboBox.setSelectedItem(Settings.pushoverLightShakingPriorityList);
+
+        pushoverPriorityLightShakingPanel.add(new JLabel("Priority for Light Shaking: "));
+        pushoverPriorityLightShakingPanel.add(pushoverLightShakingPriorityListJComboBox);
+
+        pushoverPriorityPanel.add(pushoverPriorityLightShakingPanel);
+
+        JPanel pushoverPriorityStrongShakingPanel = new JPanel();
+        pushoverPriorityStrongShakingPanel.setLayout(new BoxLayout(pushoverPriorityStrongShakingPanel, BoxLayout.X_AXIS));
+
+        DefaultComboBoxModel<Integer> model3 = new DefaultComboBoxModel<>(new Integer[]{-1, 0, 1});
+
+        pushoverStrongShakingPriorityListJComboBox = new JComboBox<>(model3);
+
+        pushoverStrongShakingPriorityListJComboBox.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value instanceof Integer) {
+                    switch ((Integer) value) {
+                        case -1: value = "Low"; break;
+                        case 0: value = "Normal"; break;
+                        case 1: value = "High"; break;
+                    }
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
+        pushoverStrongShakingPriorityListJComboBox.setSelectedItem(Settings.pushoverStrongShakingPriorityList);
+
+        pushoverPriorityStrongShakingPanel.add(new JLabel("Priority for Strong Shaking: "));
+        pushoverPriorityStrongShakingPanel.add(pushoverStrongShakingPriorityListJComboBox);
+
+        pushoverPriorityPanel.add(pushoverPriorityStrongShakingPanel);
+
+        panel.add(pushoverPriorityPanel);
+
+        chkBoxPushoverCustomSounds = new JCheckBox("Use custom sounds for Pushover", Settings.usePushoverCustomSounds);
+        textFieldPushoverSoundFeltLight = new JTextField(Settings.pushoverSoundFeltLight, 12);
+        textFieldPushoverSoundFeltLight.setEnabled(chkBoxPushoverCustomSounds.isSelected());
+        textFieldPushoverSoundFeltStrong = new JTextField(Settings.pushoverSoundFeltStrong, 12);
+        textFieldPushoverSoundFeltStrong.setEnabled(chkBoxPushoverCustomSounds.isSelected());
+        textFieldPushoverSoundDetected = new JTextField(Settings.pushoverSoundDetected, 12);
+        textFieldPushoverSoundDetected.setEnabled(chkBoxPushoverCustomSounds.isSelected());
+        chkBoxPushoverCustomSounds.addChangeListener(changeEvent -> {
+            textFieldPushoverSoundFeltLight.setEnabled(chkBoxPushoverCustomSounds.isSelected());
+            textFieldPushoverSoundFeltStrong.setEnabled(chkBoxPushoverCustomSounds.isSelected());
+            textFieldPushoverSoundDetected.setEnabled(chkBoxPushoverCustomSounds.isSelected());
+        });
+
+        JPanel pushoverCustomSoundsPanel = new JPanel(new GridLayout(4, 1));
+        pushoverCustomSoundsPanel.setBorder(BorderFactory.createTitledBorder("Custom Sounds"));
+
+        JPanel pushoverUseCustomSoundsPanel = new JPanel();
+        pushoverUseCustomSoundsPanel.setLayout(new BoxLayout(pushoverUseCustomSoundsPanel, BoxLayout.X_AXIS));
+        pushoverUseCustomSoundsPanel.add(chkBoxPushoverCustomSounds);
+
+        pushoverCustomSoundsPanel.add(pushoverUseCustomSoundsPanel);
+
+        JPanel pushoverSoundDetectedPanel = new JPanel();
+        pushoverSoundDetectedPanel.setLayout(new BoxLayout(pushoverSoundDetectedPanel, BoxLayout.X_AXIS));
+        pushoverSoundDetectedPanel.add(new JLabel("Sound for Detected Earthquake: "));
+        pushoverSoundDetectedPanel.add(textFieldPushoverSoundDetected);
+
+        pushoverCustomSoundsPanel.add(pushoverSoundDetectedPanel);
+
+        JPanel pushoverSoundFeltLightPanel = new JPanel();
+        pushoverSoundFeltLightPanel.setLayout(new BoxLayout(pushoverSoundFeltLightPanel, BoxLayout.X_AXIS));
+        pushoverSoundFeltLightPanel.add(new JLabel("Sound for Light Shaking: "));
+        pushoverSoundFeltLightPanel.add(textFieldPushoverSoundFeltLight);
+
+        pushoverCustomSoundsPanel.add(pushoverSoundFeltLightPanel);
+
+        JPanel pushoverSoundFeltStrongPanel = new JPanel();
+        pushoverSoundFeltStrongPanel.setLayout(new BoxLayout(pushoverSoundFeltStrongPanel, BoxLayout.X_AXIS));
+        pushoverSoundFeltStrongPanel.add(new JLabel("Sound for Strong Shaking: "));
+        pushoverSoundFeltStrongPanel.add(textFieldPushoverSoundFeltStrong);
+
+        pushoverCustomSoundsPanel.add(pushoverSoundFeltStrongPanel);
+
+        panel.add(pushoverCustomSoundsPanel);
+
+        return panel;
+    }
+
     @Override
     public void refreshUI() {
         chkBoxLocal.setText("Alert when any earthquake occurs closer than (%s): ".formatted(Settings.getSelectedDistanceUnit().getShortName()));
@@ -282,6 +653,26 @@ public class AlertSettingsPanel extends SettingsPanel {
         Settings.eewScale = eewThreshold.getShakingScaleComboBox().getSelectedIndex();
         Settings.eewLevelIndex = eewThreshold.getLevelComboBox().getSelectedIndex();
         Settings.eewClusterLevel = (Integer) comboBoxEEWClusterLevel.getSelectedItem();
+
+        Settings.useNtfy = chkBoxNtfy.isSelected();
+        Settings.usePushover = chkBoxPushover.isSelected();
+        Settings.ntfy = textFieldNtfy.getText();
+        Settings.pushoverUserID = textFieldPushoverUserID.getText();
+        Settings.pushoverToken = textFieldPushoverToken.getText();
+        Settings.usePushoverCustomSounds = chkBoxPushoverCustomSounds.isSelected();
+        Settings.pushoverSoundDetected = textFieldPushoverSoundDetected.getText();
+        Settings.pushoverSoundFeltLight = textFieldPushoverSoundFeltLight.getText();
+        Settings.pushoverSoundFeltStrong = textFieldPushoverSoundFeltStrong.getText();
+        Settings.ntfyNearbyShaking = chkBoxNtfyNearbyShaking.isSelected();
+        Settings.ntfyFeltShaking = chkBoxNtfyFeltShaking.isSelected();
+        Settings.ntfyNearbyShakingPriorityList = (Integer) ntfyNearbyShakingPriorityListJComboBox.getSelectedItem();
+        Settings.ntfyLightShakingPriorityList = (Integer) ntfyLightShakingPriorityListJComboBox.getSelectedItem();
+        Settings.ntfyStrongShakingPriorityList = (Integer) ntfyStrongShakingPriorityListJComboBox.getSelectedItem();
+        Settings.pushoverNearbyShaking = chkBoxPushoverNearbyShaking.isSelected();
+        Settings.pushoverFeltShaking = chkBoxPushoverFeltShaking.isSelected();
+        Settings.pushoverNearbyShakingPriorityList = (Integer) pushoverNearbyShakingPriorityListJComboBox.getSelectedItem();
+        Settings.pushoverLightShakingPriorityList = (Integer) pushoverLightShakingPriorityListJComboBox.getSelectedItem();
+        Settings.pushoverStrongShakingPriorityList = (Integer) pushoverStrongShakingPriorityListJComboBox.getSelectedItem();
     }
 
     @Override

--- a/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
+++ b/GlobalQuakeCore/src/main/java/globalquake/ui/settings/AlertSettingsPanel.java
@@ -486,7 +486,7 @@ public class AlertSettingsPanel extends SettingsPanel {
         chkBoxPushoverNearbyShaking.addChangeListener(changeEvent -> chkBoxPushoverSendRevisions.setEnabled(chkBoxPushoverNearbyShaking.isSelected()));
         chkBoxPushoverFeltShaking = new JCheckBox("Notify when shaking is expected", Settings.pushoverFeltShaking);
 
-        JPanel pushoverShakingPanel = new JPanel(new GridLayout(4, 1));
+        JPanel pushoverShakingPanel = new JPanel(new GridLayout(3, 1));
         pushoverShakingPanel.setBorder(BorderFactory.createTitledBorder("Shaking Alerts"));
 
         JPanel pushoverNearbyShakingPanel = new JPanel();
@@ -506,13 +506,7 @@ public class AlertSettingsPanel extends SettingsPanel {
         pushoverFeltShakingPanel.add(chkBoxPushoverFeltShaking);
 
         pushoverShakingPanel.add(pushoverFeltShakingPanel);
-
-        JPanel pushoverShakingMessagePanel = new JPanel();
-        pushoverShakingMessagePanel.setLayout(new BoxLayout(pushoverShakingMessagePanel, BoxLayout.X_AXIS));
-        pushoverShakingMessagePanel.add(new JLabel("Enable Earthquake Reports in Debug Settings to receive Final Reports"));
-
-        pushoverShakingPanel.add(pushoverShakingMessagePanel);
-
+        
         panel.add(pushoverShakingPanel);
 
         JPanel pushoverPriorityPanel = new JPanel(new GridLayout(3, 1));

--- a/GlobalQuakeServer/src/main/java/gqserver/main/Main.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/main/Main.java
@@ -15,6 +15,8 @@ import gqserver.bot.DiscordBot;
 import gqserver.fdsnws_event.FdsnwsEventsHTTPServer;
 
 import globalquake.utils.Scale;
+import gqserver.push_notification.PushNotificationNtfy;
+import gqserver.push_notification.PushNotificationPushover;
 import gqserver.server.GlobalQuakeServer;
 import gqserver.ui.server.DatabaseMonitorFrame;
 import org.apache.commons.cli.*;
@@ -177,6 +179,18 @@ public class Main {
         updateProgressBar("Starting Discord Bot...", (int) ((phase++ / PHASES) * 100.0));
         if (Settings.discordBotEnabled) {
             DiscordBot.init();
+        }
+
+        updateProgressBar("Starting Push Notification Ntfy...", (int) ((phase++ / PHASES) * 100.0));
+        if (Settings.useNtfy) {
+            PushNotificationNtfy.init();
+            PushNotificationNtfy.startNotification();
+        }
+
+        updateProgressBar("Starting Push Notification Pushover...", (int) ((phase++ / PHASES) * 100.0));
+        if (Settings.usePushover) {
+            PushNotificationPushover.init();
+            PushNotificationPushover.startNotification();
         }
 
         updateProgressBar("Updating Station Sources...", (int) ((phase++ / PHASES) * 100.0));

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
@@ -40,6 +40,7 @@ public class PushNotificationNtfy extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
+                    maxHomeShakingIntensity = 0;
                     homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
                     // if newly detected earthquake is felt, send notification
                     if (homeShakingIntensity > 0) {
@@ -55,10 +56,9 @@ public class PushNotificationNtfy extends ListenerAdapter {
                     if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
                         sendQuakeCreateInfoEEW(event.earthquake());
                         maxHomeShakingIntensity = homeShakingIntensity;
-                    // if current earthquake was shown as felt but shaking is not expected, send notification and stop notifying
+                    // if current earthquake was shown as felt but shaking is not expected, send notification
                     } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
-                        maxHomeShakingIntensity = 0;
                     // otherwise, update the notification
                     } else if (homeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
@@ -88,11 +88,11 @@ public class PushNotificationNtfy extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
+                    maxHomeShakingIntensity = 0;
                     homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
                     // Do not send nearby Earthquake notification when user is already warned about felt shaking
                     if (!(Settings.ntfyFeltShaking && homeShakingIntensity > 0)) {
                         sendQuakeCreateInfo(event.earthquake());
-                        maxHomeShakingIntensity = 0; // Prevent sending no shaking expected notification
                     }
                 }
 
@@ -102,7 +102,6 @@ public class PushNotificationNtfy extends ListenerAdapter {
                     // Do not send nearby Earthquake notification when user is already warned about felt shaking
                     if (!(Settings.ntfyFeltShaking && homeShakingIntensity > 0)) {
                         sendQuakeUpdateInfo(event.earthquake());
-                        maxHomeShakingIntensity = 0;
                     }
                 }
 
@@ -117,7 +116,6 @@ public class PushNotificationNtfy extends ListenerAdapter {
                     // Do not send nearby Earthquake notification when user is already warned about felt shaking
                     if (!(Settings.ntfyFeltShaking && homeShakingIntensity > 0)) {
                         sendQuakeRemoveInfo(event.earthquake());
-                        maxHomeShakingIntensity = 0;
                     }
                 }
             });

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
@@ -49,13 +49,13 @@ public class PushNotificationNtfy extends ListenerAdapter {
                     earthquakeList[currentEarthquake][1] = String.valueOf(determineHomeShakingIntensity(event.earthquake()));
                     earthquakeList[currentEarthquake][2] = earthquakeList[currentEarthquake][1];
 
-                    if (Settings.ntfyNearbyShaking && Settings.ntfyFeltShaking) {
+                    if ((Settings.ntfyNearbyShaking && Settings.ntfySendRevisions) && Settings.ntfyFeltShaking) {
                         if (earthquakeList[currentEarthquake][1].equals("0")) {
                             sendQuakeCreateInfo(event.earthquake());
                         } else {
                             sendQuakeCreateInfoEEW(event.earthquake());
                         }
-                    } else if (Settings.ntfyNearbyShaking) {
+                    } else if (Settings.ntfyNearbyShaking && Settings.ntfySendRevisions) {
                         sendQuakeCreateInfo(event.earthquake());
                     } else if (Settings.ntfyFeltShaking) {
                         if (!earthquakeList[currentEarthquake][1].equals("0")) {
@@ -70,13 +70,13 @@ public class PushNotificationNtfy extends ListenerAdapter {
                         if (earthquakeList[i][0] != null && earthquakeList[i][0].equals(String.valueOf(event.earthquake().getUuid()))) {
                             earthquakeList[i][1] = String.valueOf(determineHomeShakingIntensity(event.earthquake()));
 
-                            if (Settings.ntfyNearbyShaking && Settings.ntfyFeltShaking) {
+                            if ((Settings.ntfyNearbyShaking && Settings.ntfySendRevisions) && Settings.ntfyFeltShaking) {
                                 if (earthquakeList[currentEarthquake][1].equals("0") && earthquakeList[currentEarthquake][2].equals("0")) {
                                     sendQuakeUpdateInfo(event.earthquake());
                                 } else {
                                     determineType(event, i);
                                 }
-                            } else if (Settings.ntfyNearbyShaking) {
+                            } else if (Settings.ntfyNearbyShaking && Settings.ntfySendRevisions) {
                                 sendQuakeUpdateInfo(event.earthquake());
                             } else if (Settings.ntfyFeltShaking) {
                                 determineType(event, i);
@@ -99,13 +99,13 @@ public class PushNotificationNtfy extends ListenerAdapter {
                 public void onQuakeRemove(QuakeRemoveEvent event) {
                     for (int i = 0; i < 99; i++) {
                         if (earthquakeList[i][0] != null && earthquakeList[i][0].equals(String.valueOf(event.earthquake().getUuid()))) {
-                            if (Settings.ntfyNearbyShaking && Settings.ntfyFeltShaking) {
+                            if ((Settings.ntfyNearbyShaking && Settings.ntfySendRevisions) && Settings.ntfyFeltShaking) {
                                 if (earthquakeList[currentEarthquake][1].equals("0") && earthquakeList[currentEarthquake][2].equals("0")) {
                                     sendQuakeRemoveInfo(event.earthquake());
                                 } else {
                                     sendQuakeRemoveInfoEEW(event.earthquake());
                                 }
-                            } else if (Settings.ntfyNearbyShaking) {
+                            } else if (Settings.ntfyNearbyShaking && Settings.ntfySendRevisions) {
                                 sendQuakeRemoveInfo(event.earthquake());
                             } else if (Settings.ntfyFeltShaking) {
                                 if (!earthquakeList[currentEarthquake][1].equals("0")) {

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
@@ -55,9 +55,10 @@ public class PushNotificationNtfy extends ListenerAdapter {
                     if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
                         sendQuakeCreateInfoEEW(event.earthquake());
                         maxHomeShakingIntensity = homeShakingIntensity;
-                    // if current earthquake was shown as felt but shaking is not expected, send notification
+                    // if current earthquake was shown as felt but shaking is not expected, send notification and stop notifying
                     } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
+                        maxHomeShakingIntensity = 0;
                     // otherwise, update the notification
                     } else if (homeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
@@ -87,12 +88,22 @@ public class PushNotificationNtfy extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
-                    sendQuakeCreateInfo(event.earthquake());
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
+                    if (!(Settings.ntfyFeltShaking && homeShakingIntensity > 0)) {
+                        sendQuakeCreateInfo(event.earthquake());
+                        maxHomeShakingIntensity = 0; // Prevent sending no shaking expected notification
+                    }
                 }
 
                 @Override
                 public void onQuakeUpdate(QuakeUpdateEvent event) {
-                    sendQuakeUpdateInfo(event.earthquake());
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
+                    if (!(Settings.ntfyFeltShaking && homeShakingIntensity > 0)) {
+                        sendQuakeUpdateInfo(event.earthquake());
+                        maxHomeShakingIntensity = 0;
+                    }
                 }
 
                 @Override
@@ -102,7 +113,12 @@ public class PushNotificationNtfy extends ListenerAdapter {
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    sendQuakeRemoveInfo(event.earthquake());
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
+                    if (!(Settings.ntfyFeltShaking && homeShakingIntensity > 0)) {
+                        sendQuakeRemoveInfo(event.earthquake());
+                        maxHomeShakingIntensity = 0;
+                    }
                 }
             });
         }

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
@@ -73,7 +73,10 @@ public class PushNotificationNtfy extends ListenerAdapter {
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    sendQuakeRemoveInfoEEW(event.earthquake());
+                    // if user was warned about the earthquake, send a notification that the earthquake was cancelled
+                    if (maxHomeShakingIntensity > 0) {
+                        sendQuakeRemoveInfoEEW(event.earthquake());
+                    }
                     homeShakingIntensity = 0;
                     maxHomeShakingIntensity = 0;
                 }

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
@@ -84,25 +84,21 @@ public class PushNotificationNtfy extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeCreateInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeUpdate(QuakeUpdateEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeUpdateInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeReport(QuakeReportEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeReportInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeRemoveInfo(event.earthquake());
                 }
             });

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationNtfy.java
@@ -1,0 +1,335 @@
+package gqserver.push_notification;
+
+import globalquake.core.GlobalQuake;
+import globalquake.core.earthquake.data.Earthquake;
+import globalquake.core.events.GlobalQuakeEventListener;
+import globalquake.core.events.specific.QuakeCreateEvent;
+import globalquake.core.events.specific.QuakeRemoveEvent;
+import globalquake.core.events.specific.QuakeReportEvent;
+import globalquake.core.events.specific.QuakeUpdateEvent;
+import globalquake.core.geo.DistanceUnit;
+import globalquake.core.geo.taup.TauPTravelTimeCalculator;
+import globalquake.core.intensity.IntensityScales;
+import globalquake.core.intensity.Level;
+import globalquake.utils.GeoUtils;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import globalquake.core.Settings;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+
+public class PushNotificationNtfy extends ListenerAdapter {
+
+    private static final Set<Earthquake> measuredQuakes = new HashSet<>();
+
+    private static int homeShakingIntensity;
+    private static int maxHomeShakingIntensity;
+    private static String homeMMI;
+    private static String homeShindo;
+
+    public static void init() {
+        // for felt earthquakes
+        if (Settings.ntfyFeltShaking) {
+            GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
+                @Override
+                public void onQuakeCreate(QuakeCreateEvent event) {
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // if newly detected earthquake is felt, send notification
+                    if (homeShakingIntensity > 0) {
+                        sendQuakeCreateInfoEEW(event.earthquake());
+                        maxHomeShakingIntensity = homeShakingIntensity;
+                    }
+                }
+
+                @Override
+                public void onQuakeUpdate(QuakeUpdateEvent event) {
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // if current earthquake was not felt but now is, send notification
+                    if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
+                        sendQuakeCreateInfoEEW(event.earthquake());
+                        maxHomeShakingIntensity = homeShakingIntensity;
+                    // if current earthquake was shown as felt but shaking is not expected, send notification
+                    } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
+                        sendQuakeUpdateInfoEEW(event.earthquake());
+                    // otherwise, update the notification
+                    } else if (homeShakingIntensity > 0) {
+                        sendQuakeUpdateInfoEEW(event.earthquake());
+                    }
+                }
+
+                @Override
+                public void onQuakeReport(QuakeReportEvent event) {
+                    // after the earthquake is reported, reset the shaking intensity
+                    homeShakingIntensity = 0;
+                    maxHomeShakingIntensity = 0;
+                }
+
+                @Override
+                public void onQuakeRemove(QuakeRemoveEvent event) {
+                    sendQuakeRemoveInfoEEW(event.earthquake());
+                    homeShakingIntensity = 0;
+                    maxHomeShakingIntensity = 0;
+                }
+            });
+        }
+        // for nearby earthquakes
+        if (Settings.ntfyNearbyShaking) {
+            GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
+                @Override
+                public void onQuakeCreate(QuakeCreateEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeCreateInfo(event.earthquake());
+                }
+
+                @Override
+                public void onQuakeUpdate(QuakeUpdateEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeUpdateInfo(event.earthquake());
+                }
+
+                @Override
+                public void onQuakeReport(QuakeReportEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeReportInfo(event.earthquake());
+                }
+
+                @Override
+                public void onQuakeRemove(QuakeRemoveEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeRemoveInfo(event.earthquake());
+                }
+            });
+        }
+    }
+
+    private static void sendQuakeCreateInfo(Earthquake earthquake) {
+        if (!Settings.useNtfy || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Earthquake Detected";
+
+        sendNotification(Title, createDescription(earthquake), Settings.ntfyNearbyShakingPriorityList);
+    }
+
+    private static void sendQuakeCreateInfoEEW(Earthquake earthquake) {
+        if (!Settings.useNtfy) {
+            return;
+        }
+
+        String Title = "";
+        int priority = 2;
+
+        if (homeShakingIntensity == 1) {
+            priority = Settings.ntfyLightShakingPriorityList;
+            Title = "Light shaking is expected";
+        } else if (homeShakingIntensity == 2) {
+            priority = Settings.ntfyStrongShakingPriorityList;
+            Title = "Strong shaking is expected";
+        }
+
+        sendNotification(Title, createDescription(earthquake), priority);
+    }
+
+    private static void sendQuakeUpdateInfo(Earthquake earthquake) {
+        if (!Settings.useNtfy || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Revision #%d".formatted(earthquake.getRevisionID());
+
+        sendNotification(Title, createDescription(earthquake), 2);
+    }
+
+    private static void sendQuakeUpdateInfoEEW(Earthquake earthquake) {
+        if (!Settings.useNtfy) {
+            return;
+        }
+
+        String Title = "";
+        int priority = 2; // do not make an audible notification when revising, unless shaking intensity increased
+
+        if (homeShakingIntensity == 0) {
+            Title = "No shaking is expected";
+        }
+        else if (homeShakingIntensity == 1) {
+            Title = "Light shaking is expected";
+        } else if (homeShakingIntensity == 2) {
+            Title = "Strong shaking is expected";
+        }
+
+        // if shaking intensity increased, prioritize the notification
+        if (maxHomeShakingIntensity < homeShakingIntensity) {
+            priority = Settings.ntfyStrongShakingPriorityList;
+            maxHomeShakingIntensity = homeShakingIntensity;
+        }
+
+        sendNotification(Title, createDescription(earthquake), priority);
+    }
+
+    private static void sendQuakeReportInfo(Earthquake earthquake) {
+        if (!Settings.useNtfy || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Final quake report";
+
+        sendNotification(Title, createDescription(earthquake), Settings.ntfyNearbyShakingPriorityList);
+    }
+
+    private static void sendQuakeRemoveInfo(Earthquake earthquake) {
+        if (!Settings.useNtfy || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Cancelled Earthquake";
+        String message = "M%.1f %s".formatted(earthquake.getMag(), earthquake.getRegion());
+
+        sendNotification(Title, message, Settings.ntfyNearbyShakingPriorityList);
+    }
+
+    private static void sendQuakeRemoveInfoEEW(Earthquake earthquake) {
+        if (!Settings.useNtfy) {
+            return;
+        }
+
+        String Title = "Early Earthquake Warning Cancelled";
+        String message = "M%.1f %s".formatted(earthquake.getMag(), earthquake.getRegion());
+
+        sendNotification(Title, message, 3);
+    }
+
+    private static void sendNotification(String title, String description, int priority) {
+
+        if (!Settings.useNtfy) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                URL url = new URL(Settings.ntfy);
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                connection.setRequestMethod("POST");
+                connection.setRequestProperty("title", title);
+                connection.setRequestProperty("priority", String.valueOf(priority));
+                connection.setDoOutput(true);
+
+                try (OutputStream os = connection.getOutputStream()) {
+                    byte[] input = description.getBytes(StandardCharsets.UTF_8);
+                    os.write(input, 0, input.length);
+                }
+
+                int responseCode = connection.getResponseCode();
+                System.out.println("Ntfy Detected earthquake nearby. Response Code: " + responseCode); // Debugging
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+    private static String formatLevel(Level level) {
+        if (level == null) {
+            return "-";
+        } else {
+            return level.toString();
+        }
+    }
+
+    public static void startNotification() {
+        String title = "Server Starting";
+        try {
+            URL url = new URL(Settings.ntfy);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("title", title);
+            connection.setRequestProperty("priority", "3");
+            connection.setDoOutput(true);
+
+            String message = "This may take a few minutes to complete.";
+
+            try (OutputStream os = connection.getOutputStream()) {
+                byte[] input = message.getBytes(StandardCharsets.UTF_8);
+                os.write(input, 0, input.length);
+            }
+
+            int responseCode = connection.getResponseCode();
+            System.out.println("Start message. Response Code: " + responseCode); // Debugging
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static long bestDetectionTime = Long.MAX_VALUE;
+    private static double detectionTimeSum = 0.0;
+    private static int detections = 0;
+
+    private static String createDescription(Earthquake earthquake) {
+        String description = "M%.1f %s".formatted(
+                earthquake.getMag(),
+                earthquake.getRegion());
+
+        double pga = GeoUtils.getMaxPGA(earthquake.getLat(), earthquake.getLon(), earthquake.getDepth(), earthquake.getMag());
+
+        long detectionTime = earthquake.getCreatedAt() - earthquake.getOrigin();
+        if (detectionTime < bestDetectionTime) {
+            bestDetectionTime = detectionTime;
+        }
+
+        if (!measuredQuakes.contains(earthquake)) {
+            detections++;
+            detectionTimeSum += detectionTime / 1000.0;
+            measuredQuakes.add(earthquake);
+        }
+
+        description += "\n" +
+                "Depth: %.1fkm / %.1fmi\n".formatted(earthquake.getDepth(), earthquake.getDepth() * DistanceUnit.MI.getKmRatio()) +
+                        "MMI: %s / Shindo: %s\n".formatted(formatLevel(IntensityScales.MMI.getLevel(pga)),
+                                formatLevel(IntensityScales.SHINDO.getLevel(pga))) +
+                        "Home MMI: %s / Shindo: %s\n".formatted(homeMMI, homeShindo) +
+                        "SWave Arrival: %ds\n".formatted(calculateSWaveArrival(earthquake)) +
+                        "Time: %s\n".formatted(Settings.formatDateTime(Instant.ofEpochMilli(earthquake.getOrigin()))) +
+                        "Detection Time: %.1fs (best %.1fs, avg %.1fs)\n".formatted(detectionTime / 1000.0, bestDetectionTime / 1000.0, detectionTimeSum / detections) +
+                        "Quality: %s (%d stations)".formatted(earthquake.getCluster().getPreviousHypocenter().quality.getSummary(), earthquake.getCluster().getAssignedEvents().size());
+
+        return description;
+    }
+
+    private static int determineHomeShakingIntensity(Earthquake earthquake) {
+        double _dist = GeoUtils.geologicalDistance(earthquake.getLat(), earthquake.getLon(), -earthquake.getDepth(), Settings.homeLat, Settings.homeLon, 0);
+        double pga = GeoUtils.pgaFunction(earthquake.getMag(), _dist, earthquake.getDepth());
+
+        homeMMI = formatLevel(IntensityScales.MMI.getLevel(pga));
+        homeShindo = formatLevel(IntensityScales.SHINDO.getLevel(pga));
+
+        if (pga >= IntensityScales.INTENSITY_SCALES[Settings.shakingLevelScale].getLevels().get(Settings.shakingLevelIndex).getPga()) {
+            return 1; // weak shaking
+        } else if (pga >= IntensityScales.INTENSITY_SCALES[Settings.strongShakingLevelScale].getLevels().get(Settings.strongShakingLevelIndex).getPga()) {
+            return 2; // strong shaking
+        } else {
+            return 0; // no shaking
+        }
+    }
+
+    private static int calculateSWaveArrival(Earthquake earthquake) {
+        double distGC = GeoUtils.greatCircleDistance(earthquake.getLat(), earthquake.getLon(), Settings.homeLat, Settings.homeLon);
+        double age = (GlobalQuake.instance.currentTimeMillis() - earthquake.getOrigin()) / 1000.0;
+
+        double sTravel = TauPTravelTimeCalculator.getSWaveTravelTime(earthquake.getDepth(), TauPTravelTimeCalculator.toAngle(distGC));
+
+        int sArrival = (int) Math.round(sTravel - age) - 1; // There is 1-second delay when sending the message
+
+        return Math.max(sArrival, 0);
+    }
+
+    private static boolean isQuakeNearby(Earthquake earthquake) {
+        double distGC = GeoUtils.greatCircleDistance(earthquake.getLat(), earthquake.getLon(), Settings.homeLat, Settings.homeLon);
+
+        return distGC <= Settings.alertLocalDist || (distGC <= Settings.alertRegionDist && earthquake.getMag() >= Settings.alertRegionMag);
+    }
+}

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -1,0 +1,350 @@
+package gqserver.push_notification;
+
+import globalquake.core.GlobalQuake;
+import globalquake.core.earthquake.data.Earthquake;
+import globalquake.core.events.GlobalQuakeEventListener;
+import globalquake.core.events.specific.QuakeCreateEvent;
+import globalquake.core.events.specific.QuakeRemoveEvent;
+import globalquake.core.events.specific.QuakeReportEvent;
+import globalquake.core.events.specific.QuakeUpdateEvent;
+import globalquake.core.geo.DistanceUnit;
+import globalquake.core.geo.taup.TauPTravelTimeCalculator;
+import globalquake.core.intensity.IntensityScales;
+import globalquake.core.intensity.Level;
+import globalquake.utils.GeoUtils;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import globalquake.core.Settings;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+
+public class PushNotificationPushover extends ListenerAdapter {
+
+    private static final String PUSHOVER_URL = "https://api.pushover.net/1/messages.json";
+    private static final Set<Earthquake> measuredQuakes = new HashSet<>();
+
+    private static int homeShakingIntensity;
+    private static int maxHomeShakingIntensity;
+    private static String homeMMI;
+    private static String homeShindo;
+
+    public static void init() {
+        // for felt earthquakes
+        if (Settings.pushoverFeltShaking) {
+            GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
+                @Override
+                public void onQuakeCreate(QuakeCreateEvent event) {
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // if newly detected earthquake is felt, send notification
+                    if (homeShakingIntensity > 0) {
+                        sendQuakeCreateInfoEEW(event.earthquake());
+                        maxHomeShakingIntensity = homeShakingIntensity;
+                    }
+                }
+
+                @Override
+                public void onQuakeUpdate(QuakeUpdateEvent event) {
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // if current earthquake was not felt but now is, send notification
+                    if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
+                        sendQuakeCreateInfoEEW(event.earthquake());
+                        maxHomeShakingIntensity = homeShakingIntensity;
+                        // if current earthquake was shown as felt but shaking is not expected, send notification
+                    } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
+                        sendQuakeUpdateInfoEEW(event.earthquake());
+                        // otherwise, update the notification
+                    } else if (homeShakingIntensity > 0) {
+                        sendQuakeUpdateInfoEEW(event.earthquake());
+                    }
+                }
+
+                @Override
+                public void onQuakeReport(QuakeReportEvent event) {
+                    // after the earthquake is reported, reset the shaking intensity
+                    homeShakingIntensity = 0;
+                    maxHomeShakingIntensity = 0;
+                }
+
+                @Override
+                public void onQuakeRemove(QuakeRemoveEvent event) {
+                    sendQuakeRemoveInfoEEW(event.earthquake());
+                    homeShakingIntensity = 0;
+                    maxHomeShakingIntensity = 0;
+                }
+            });
+        }
+        // for nearby earthquakes
+        if (Settings.pushoverNearbyShaking) {
+            GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
+                @Override
+                public void onQuakeCreate(QuakeCreateEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeCreateInfo(event.earthquake());
+                }
+
+                @Override
+                public void onQuakeUpdate(QuakeUpdateEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeUpdateInfo(event.earthquake());
+                }
+
+                @Override
+                public void onQuakeReport(QuakeReportEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeReportInfo(event.earthquake());
+                }
+
+                @Override
+                public void onQuakeRemove(QuakeRemoveEvent event) {
+                    isQuakeNearby(event.earthquake());
+                    sendQuakeRemoveInfo(event.earthquake());
+                }
+            });
+        }
+    }
+
+    private static void sendQuakeCreateInfo(Earthquake earthquake) {
+        if (!Settings.usePushover || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Earthquake Detected";
+
+        sendNotification(Title, createDescription(earthquake), Settings.pushoverNearbyShakingPriorityList,
+                Settings.usePushoverCustomSounds, Settings.pushoverSoundDetected);
+    }
+
+    private static void sendQuakeCreateInfoEEW(Earthquake earthquake) {
+        if (!Settings.usePushover) {
+            return;
+        }
+
+        String Title = "";
+        String customSound = "";
+        int priority = -1;
+
+        if (homeShakingIntensity == 1) {
+            priority = Settings.pushoverLightShakingPriorityList;
+            customSound = Settings.pushoverSoundFeltLight;
+            Title = "Light shaking is expected";
+        } else if (homeShakingIntensity == 2) {
+            priority = Settings.pushoverStrongShakingPriorityList;
+            customSound = Settings.pushoverSoundFeltStrong;
+            Title = "Strong shaking is expected";
+        }
+
+        sendNotification(Title, createDescription(earthquake), priority, Settings.usePushoverCustomSounds, customSound);
+    }
+
+    private static void sendQuakeUpdateInfo(Earthquake earthquake) {
+        if (!Settings.usePushover || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Revision #%d".formatted(earthquake.getRevisionID());
+
+        sendNotification(Title, createDescription(earthquake), 0, false, null);
+    }
+
+    private static void sendQuakeUpdateInfoEEW(Earthquake earthquake) {
+        if (!Settings.usePushover) {
+            return;
+        }
+
+        String Title = "";
+        String customSound = "";
+        int priority = 2; // do not make an audible notification when revising, unless shaking intensity increased
+
+        if (homeShakingIntensity == 0) {
+            Title = "No shaking is expected";
+        }
+        else if (homeShakingIntensity == 1) {
+            Title = "Light shaking is expected";
+        } else if (homeShakingIntensity == 2) {
+            Title = "Strong shaking is expected";
+        }
+
+        // if shaking intensity increased, prioritize the notification
+        if (maxHomeShakingIntensity < homeShakingIntensity) {
+            priority = Settings.pushoverStrongShakingPriorityList;
+            customSound = Settings.pushoverSoundFeltStrong;
+            maxHomeShakingIntensity = homeShakingIntensity;
+        }
+
+        sendNotification(Title, createDescription(earthquake), priority, false, customSound);
+    }
+
+    private static void sendQuakeReportInfo(Earthquake earthquake) {
+        if (!Settings.usePushover || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Final quake report";
+
+        sendNotification(Title, createDescription(earthquake), Settings.pushoverNearbyShakingPriorityList,
+                Settings.usePushoverCustomSounds, Settings.pushoverSoundDetected);
+    }
+
+    private static void sendQuakeRemoveInfo(Earthquake earthquake) {
+        if (!Settings.usePushover || !isQuakeNearby(earthquake)) {
+            return;
+        }
+
+        String Title = "Cancelled Earthquake";
+        String message = "M%.1f %s".formatted(earthquake.getMag(), earthquake.getRegion());
+
+        sendNotification(Title, message, 0, false, null);
+    }
+
+    private static void sendQuakeRemoveInfoEEW(Earthquake earthquake) {
+        if (!Settings.usePushover) {
+            return;
+        }
+
+        String Title = "Early Earthquake Warning Cancelled";
+        String message = "M%.1f %s".formatted(earthquake.getMag(), earthquake.getRegion());
+
+        sendNotification(Title, message, 0, false, null);
+    }
+
+    private static void sendNotification(String title, String description, int priority, boolean useCustomSounds, String customSound) {
+        if (!Settings.usePushover) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            String urlParametersPushover = "token=" + Settings.pushoverToken +
+                    "&user=" + Settings.pushoverUserID +
+                    "&priority=" + priority +
+                    "&title=" + title +
+                    "&message=" + description;
+            if (useCustomSounds) {
+                urlParametersPushover += "&sound=" + customSound;
+            }
+            try {
+                URL url = new URL(PUSHOVER_URL);
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                conn.setDoOutput(true);
+
+                byte[] postData = urlParametersPushover.getBytes(StandardCharsets.UTF_8);
+                try (OutputStream os = conn.getOutputStream()) {
+                    os.write(postData, 0, postData.length);
+                }
+
+                int responseCode = conn.getResponseCode();
+                System.out.println("Pushover detected earthquake nearby. Response Code: " + responseCode);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+    private static String formatLevel(Level level) {
+        if (level == null) {
+            return "-";
+        } else {
+            return level.toString();
+        }
+    }
+
+    public static void startNotification() {
+        String urlParametersPushover = "token=" + Settings.pushoverToken +
+                "&user=" + Settings.pushoverUserID +
+                "&priority=" + 0 +
+                "&title=Server Starting" +
+                "&message=This may take a few minutes to complete.";
+        try {
+            URL url = new URL(PUSHOVER_URL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            conn.setDoOutput(true);
+
+            byte[] postData = urlParametersPushover.getBytes(StandardCharsets.UTF_8);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(postData, 0, postData.length);
+            }
+
+            int responseCode = conn.getResponseCode();
+            System.out.println("Start message. Response Code: " + responseCode);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static long bestDetectionTime = Long.MAX_VALUE;
+    private static double detectionTimeSum = 0.0;
+    private static int detections = 0;
+
+    private static String createDescription(Earthquake earthquake) {
+        String description = "M%.1f %s".formatted(
+                earthquake.getMag(),
+                earthquake.getRegion());
+
+        double pga = GeoUtils.getMaxPGA(earthquake.getLat(), earthquake.getLon(), earthquake.getDepth(), earthquake.getMag());
+
+        long detectionTime = earthquake.getCreatedAt() - earthquake.getOrigin();
+        if (detectionTime < bestDetectionTime) {
+            bestDetectionTime = detectionTime;
+        }
+
+        if (!measuredQuakes.contains(earthquake)) {
+            detections++;
+            detectionTimeSum += detectionTime / 1000.0;
+            measuredQuakes.add(earthquake);
+        }
+
+        description += "\n" +
+                "Depth: %.1fkm / %.1fmi\n".formatted(earthquake.getDepth(), earthquake.getDepth() * DistanceUnit.MI.getKmRatio()) +
+                "MMI: %s / Shindo: %s\n".formatted(formatLevel(IntensityScales.MMI.getLevel(pga)),
+                        formatLevel(IntensityScales.SHINDO.getLevel(pga))) +
+                "Home MMI: %s / Shindo: %s\n".formatted(homeMMI, homeShindo) +
+                "SWave Arrival: %ds\n".formatted(calculateSWaveArrival(earthquake)) +
+                "Time: %s\n".formatted(Settings.formatDateTime(Instant.ofEpochMilli(earthquake.getOrigin()))) +
+                "Detection Time: %.1fs (best %.1fs, avg %.1fs)\n".formatted(detectionTime / 1000.0, bestDetectionTime / 1000.0, detectionTimeSum / detections) +
+                "Quality: %s (%d stations)".formatted(earthquake.getCluster().getPreviousHypocenter().quality.getSummary(), earthquake.getCluster().getAssignedEvents().size());
+
+        return description;
+    }
+
+    private static int determineHomeShakingIntensity(Earthquake earthquake) {
+        double _dist = GeoUtils.geologicalDistance(earthquake.getLat(), earthquake.getLon(), -earthquake.getDepth(), Settings.homeLat, Settings.homeLon, 0);
+        double pga = GeoUtils.pgaFunction(earthquake.getMag(), _dist, earthquake.getDepth());
+
+        homeMMI = formatLevel(IntensityScales.MMI.getLevel(pga));
+        homeShindo = formatLevel(IntensityScales.SHINDO.getLevel(pga));
+
+        if (pga >= IntensityScales.INTENSITY_SCALES[Settings.shakingLevelScale].getLevels().get(Settings.shakingLevelIndex).getPga()) {
+            return 1; // weak shaking
+        } else if (pga >= IntensityScales.INTENSITY_SCALES[Settings.strongShakingLevelScale].getLevels().get(Settings.strongShakingLevelIndex).getPga()) {
+            return 2; // strong shaking
+        } else {
+            return 0; // no shaking
+        }
+    }
+
+    private static int calculateSWaveArrival(Earthquake earthquake) {
+        double distGC = GeoUtils.greatCircleDistance(earthquake.getLat(), earthquake.getLon(), Settings.homeLat, Settings.homeLon);
+        double age = (GlobalQuake.instance.currentTimeMillis() - earthquake.getOrigin()) / 1000.0;
+
+        double sTravel = TauPTravelTimeCalculator.getSWaveTravelTime(earthquake.getDepth(), TauPTravelTimeCalculator.toAngle(distGC));
+
+        int sArrival = (int) Math.round(sTravel - age) - 1; // There is 1-second delay when sending the message
+
+        return Math.max(sArrival, 0);
+    }
+
+    private static boolean isQuakeNearby(Earthquake earthquake) {
+        double distGC = GeoUtils.greatCircleDistance(earthquake.getLat(), earthquake.getLon(), Settings.homeLat, Settings.homeLon);
+
+        return distGC <= Settings.alertLocalDist || (distGC <= Settings.alertRegionDist && earthquake.getMag() >= Settings.alertRegionMag);
+    }
+}

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -85,25 +85,21 @@ public class PushNotificationPushover extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeCreateInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeUpdate(QuakeUpdateEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeUpdateInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeReport(QuakeReportEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeReportInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    isQuakeNearby(event.earthquake());
                     sendQuakeRemoveInfo(event.earthquake());
                 }
             });

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -3,10 +3,7 @@ package gqserver.push_notification;
 import globalquake.core.GlobalQuake;
 import globalquake.core.earthquake.data.Earthquake;
 import globalquake.core.events.GlobalQuakeEventListener;
-import globalquake.core.events.specific.QuakeCreateEvent;
-import globalquake.core.events.specific.QuakeRemoveEvent;
-import globalquake.core.events.specific.QuakeReportEvent;
-import globalquake.core.events.specific.QuakeUpdateEvent;
+import globalquake.core.events.specific.*;
 import globalquake.core.geo.DistanceUnit;
 import globalquake.core.geo.taup.TauPTravelTimeCalculator;
 import globalquake.core.intensity.IntensityScales;
@@ -30,96 +27,110 @@ public class PushNotificationPushover extends ListenerAdapter {
     private static final String PUSHOVER_URL = "https://api.pushover.net/1/messages.json";
     private static final Set<Earthquake> measuredQuakes = new HashSet<>();
 
-    private static int homeShakingIntensity;
-    private static int maxHomeShakingIntensity;
     private static String homeMMI;
     private static String homeShindo;
 
+    private static String [][] earthquakeList = new String[100][3];
+    /*[x][0]: Quake ID
+    [x][1]: Intensity at home location
+    [x][2]: Max intensity at home location*/
+    private static int currentEarthquake = -1;
+
+
     public static void init() {
-        // for felt earthquakes
-        if (Settings.pushoverFeltShaking) {
+        if (Settings.pushoverFeltShaking || Settings.pushoverNearbyShaking) {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
-                    maxHomeShakingIntensity = 0;
-                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
-                    // if newly detected earthquake is felt, send notification
-                    if (homeShakingIntensity > 0) {
-                        sendQuakeCreateInfoEEW(event.earthquake());
-                        maxHomeShakingIntensity = homeShakingIntensity;
+                    if (currentEarthquake < 99) {
+                        currentEarthquake++;
+                    } else {
+                        currentEarthquake = 0;
+                    }
+                    earthquakeList[currentEarthquake][0] = String.valueOf(event.earthquake().getUuid());
+                    earthquakeList[currentEarthquake][1] = String.valueOf(determineHomeShakingIntensity(event.earthquake()));
+                    earthquakeList[currentEarthquake][2] = earthquakeList[currentEarthquake][1];
+
+                    if (Settings.pushoverNearbyShaking && Settings.pushoverFeltShaking) {
+                        if (earthquakeList[currentEarthquake][1].equals("0")) {
+                            sendQuakeCreateInfo(event.earthquake());
+                        } else {
+                            sendQuakeCreateInfoEEW(event.earthquake());
+                        }
+                    } else if (Settings.pushoverNearbyShaking) {
+                        sendQuakeCreateInfo(event.earthquake());
+                    } else if (Settings.pushoverFeltShaking) {
+                        if (!earthquakeList[currentEarthquake][1].equals("0")) {
+                            sendQuakeCreateInfoEEW(event.earthquake());
+                        }
                     }
                 }
 
                 @Override
                 public void onQuakeUpdate(QuakeUpdateEvent event) {
-                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
-                    // if current earthquake was not felt but now is, send notification
-                    if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
-                        sendQuakeCreateInfoEEW(event.earthquake());
-                        maxHomeShakingIntensity = homeShakingIntensity;
-                        // if current earthquake was shown as felt but shaking is not expected, send notification
-                    } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
-                        sendQuakeUpdateInfoEEW(event.earthquake());
-                        // otherwise, update the notification
-                    } else if (homeShakingIntensity > 0) {
-                        sendQuakeUpdateInfoEEW(event.earthquake());
+                    for (int i = 0; i < 99; i++) {
+                        if (earthquakeList[i][0] != null && earthquakeList[i][0].equals(String.valueOf(event.earthquake().getUuid()))) {
+                            earthquakeList[i][1] = String.valueOf(determineHomeShakingIntensity(event.earthquake()));
+
+                            if (Settings.pushoverNearbyShaking && Settings.pushoverFeltShaking) {
+                                if (earthquakeList[currentEarthquake][1].equals("0") && earthquakeList[currentEarthquake][2].equals("0")) {
+                                    sendQuakeUpdateInfo(event.earthquake());
+                                } else {
+                                    determineType(event, i);
+                                }
+                            } else if (Settings.pushoverNearbyShaking) {
+                                sendQuakeUpdateInfo(event.earthquake());
+                            } else if (Settings.pushoverFeltShaking) {
+                                determineType(event, i);
+                            }
+
+                            if (Integer.parseInt(earthquakeList[i][2]) < Integer.parseInt(earthquakeList[i][1])) {
+                                earthquakeList[i][2] = earthquakeList[i][1];
+                            }
+                        }
                     }
                 }
-
+                
                 @Override
-                public void onQuakeReport(QuakeReportEvent event) {
-                    // after the earthquake is reported, reset the shaking intensity
-                    homeShakingIntensity = 0;
-                    maxHomeShakingIntensity = 0;
+                public void onQuakeArchive(QuakeArchiveEvent event) {
+                    if (Settings.pushoverNearbyShaking)
+                        sendQuakeReportInfo(event.earthquake());
                 }
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    // if user was warned about the earthquake, send a notification that the earthquake was cancelled
-                    if (maxHomeShakingIntensity > 0) {
-                        sendQuakeRemoveInfoEEW(event.earthquake());
+                    for (int i = 0; i < 99; i++) {
+                        if (earthquakeList[i][0] != null && earthquakeList[i][0].equals(String.valueOf(event.earthquake().getUuid()))) {
+                            if (Settings.pushoverNearbyShaking && Settings.pushoverFeltShaking) {
+                                if (earthquakeList[currentEarthquake][1].equals("0") && earthquakeList[currentEarthquake][2].equals("0")) {
+                                    sendQuakeRemoveInfo(event.earthquake());
+                                } else {
+                                    sendQuakeRemoveInfoEEW(event.earthquake());
+                                }
+                            } else if (Settings.pushoverNearbyShaking) {
+                                sendQuakeRemoveInfo(event.earthquake());
+                            } else if (Settings.pushoverFeltShaking) {
+                                if (!earthquakeList[currentEarthquake][1].equals("0")) {
+                                    sendQuakeRemoveInfoEEW(event.earthquake());
+                                }
+                            }
+                        }
                     }
-                    homeShakingIntensity = 0;
-                    maxHomeShakingIntensity = 0;
                 }
             });
         }
-        // for nearby earthquakes
-        if (Settings.pushoverNearbyShaking) {
-            GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
-                @Override
-                public void onQuakeCreate(QuakeCreateEvent event) {
-                    maxHomeShakingIntensity = 0;
-                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
-                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
-                    if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
-                        sendQuakeCreateInfo(event.earthquake());
-                    }
-                }
+    }
 
-                @Override
-                public void onQuakeUpdate(QuakeUpdateEvent event) {
-                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
-                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
-                    if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
-                        sendQuakeUpdateInfo(event.earthquake());
-                    }
-                }
-
-                @Override
-                public void onQuakeReport(QuakeReportEvent event) {
-                    sendQuakeReportInfo(event.earthquake());
-                }
-
-                @Override
-                public void onQuakeRemove(QuakeRemoveEvent event) {
-                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
-                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
-                    if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
-                        sendQuakeRemoveInfo(event.earthquake());
-                    }
-                }
-            });
+    private static void determineType(QuakeUpdateEvent event, int i) {
+        // if current earthquake was not felt but now is, send notification
+        if (Integer.parseInt(earthquakeList[i][1]) > 0 && Integer.parseInt(earthquakeList[i][2]) == 0) {
+            sendQuakeCreateInfoEEW(event.earthquake());
+        // if current earthquake was shown as felt but shaking is not expected, send notification
+        } else if (Integer.parseInt(earthquakeList[i][1]) == 0 && Integer.parseInt(earthquakeList[i][2]) > 0) {
+            sendQuakeUpdateInfoEEW(event.earthquake(), i);
+        // otherwise, update the notification
+        } else if (Integer.parseInt(earthquakeList[i][1]) > 0) {
+            sendQuakeUpdateInfoEEW(event.earthquake(), i);
         }
     }
 
@@ -143,11 +154,11 @@ public class PushNotificationPushover extends ListenerAdapter {
         String customSound = "";
         int priority = -1;
 
-        if (homeShakingIntensity == 1) {
+        if (earthquakeList[currentEarthquake][1].equals("1")) {
             priority = Settings.pushoverLightShakingPriorityList;
             customSound = Settings.pushoverSoundFeltLight;
             Title = "Light shaking is expected";
-        } else if (homeShakingIntensity == 2) {
+        } else if (earthquakeList[currentEarthquake][1].equals("2")) {
             priority = Settings.pushoverStrongShakingPriorityList;
             customSound = Settings.pushoverSoundFeltStrong;
             Title = "Strong shaking is expected";
@@ -166,7 +177,7 @@ public class PushNotificationPushover extends ListenerAdapter {
         sendNotification(Title, createDescription(earthquake), -1, false, null);
     }
 
-    private static void sendQuakeUpdateInfoEEW(Earthquake earthquake) {
+    private static void sendQuakeUpdateInfoEEW(Earthquake earthquake, int currentEarthquakeUpdate) {
         if (!Settings.usePushover) {
             return;
         }
@@ -174,24 +185,23 @@ public class PushNotificationPushover extends ListenerAdapter {
         String Title = "";
         String customSound = "";
         int priority = -1; // do not make an audible notification when revising, unless shaking intensity increased
+        boolean useCustomSounds = false;
 
-        if (homeShakingIntensity == 0) {
-            Title = "No shaking is expected";
-        }
-        else if (homeShakingIntensity == 1) {
-            Title = "Light shaking is expected";
-        } else if (homeShakingIntensity == 2) {
-            Title = "Strong shaking is expected";
-        }
+        Title = switch (earthquakeList[currentEarthquakeUpdate][1]) {
+            case "0" -> "No shaking is expected";
+            case "1" -> "Light shaking is expected";
+            case "2" -> "Strong shaking is expected";
+            default -> Title;
+        };
 
         // if shaking intensity increased, prioritize the notification
-        if (maxHomeShakingIntensity < homeShakingIntensity) {
+        if (Integer.parseInt(earthquakeList[currentEarthquakeUpdate][2]) < Integer.parseInt(earthquakeList[currentEarthquakeUpdate][1])) {
             priority = Settings.pushoverStrongShakingPriorityList;
             customSound = Settings.pushoverSoundFeltStrong;
-            maxHomeShakingIntensity = homeShakingIntensity;
+            useCustomSounds = true;
         }
 
-        sendNotification(Title, createDescription(earthquake), priority, false, customSound);
+        sendNotification(Title, createDescription(earthquake), priority, useCustomSounds, customSound);
     }
 
     private static void sendQuakeReportInfo(Earthquake earthquake) {
@@ -329,8 +339,8 @@ public class PushNotificationPushover extends ListenerAdapter {
     }
 
     private static int determineHomeShakingIntensity(Earthquake earthquake) {
-        double _dist = GeoUtils.geologicalDistance(earthquake.getLat(), earthquake.getLon(), -earthquake.getDepth(), Settings.homeLat, Settings.homeLon, 0);
-        double pga = GeoUtils.pgaFunction(earthquake.getMag(), _dist, earthquake.getDepth());
+        double dist = GeoUtils.geologicalDistance(earthquake.getLat(), earthquake.getLon(), -earthquake.getDepth(), Settings.homeLat, Settings.homeLon, 0);
+        double pga = GeoUtils.pgaFunction(earthquake.getMag(), dist, earthquake.getDepth());
 
         homeMMI = formatLevel(IntensityScales.MMI.getLevel(pga));
         homeShindo = formatLevel(IntensityScales.SHINDO.getLevel(pga));

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -41,6 +41,7 @@ public class PushNotificationPushover extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
+                    maxHomeShakingIntensity = 0;
                     homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
                     // if newly detected earthquake is felt, send notification
                     if (homeShakingIntensity > 0) {
@@ -56,10 +57,9 @@ public class PushNotificationPushover extends ListenerAdapter {
                     if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
                         sendQuakeCreateInfoEEW(event.earthquake());
                         maxHomeShakingIntensity = homeShakingIntensity;
-                        // if current earthquake was shown as felt but shaking is not expected, send notification and stop notifying
+                        // if current earthquake was shown as felt but shaking is not expected, send notification
                     } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
-                        maxHomeShakingIntensity = 0;
                         // otherwise, update the notification
                     } else if (homeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
@@ -89,11 +89,11 @@ public class PushNotificationPushover extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
+                    maxHomeShakingIntensity = 0;
                     homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
                     // Do not send nearby Earthquake notification when user is already warned about felt shaking
                     if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
                         sendQuakeCreateInfo(event.earthquake());
-                        maxHomeShakingIntensity = 0; // Prevent sending no shaking expected notification
                     }
                 }
 
@@ -103,7 +103,6 @@ public class PushNotificationPushover extends ListenerAdapter {
                     // Do not send nearby Earthquake notification when user is already warned about felt shaking
                     if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
                         sendQuakeUpdateInfo(event.earthquake());
-                        maxHomeShakingIntensity = 0;
                     }
                 }
 
@@ -118,7 +117,6 @@ public class PushNotificationPushover extends ListenerAdapter {
                     // Do not send nearby Earthquake notification when user is already warned about felt shaking
                     if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
                         sendQuakeRemoveInfo(event.earthquake());
-                        maxHomeShakingIntensity = 0;
                     }
                 }
             });

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -56,9 +56,10 @@ public class PushNotificationPushover extends ListenerAdapter {
                     if (homeShakingIntensity > 0 && maxHomeShakingIntensity == 0) {
                         sendQuakeCreateInfoEEW(event.earthquake());
                         maxHomeShakingIntensity = homeShakingIntensity;
-                        // if current earthquake was shown as felt but shaking is not expected, send notification
+                        // if current earthquake was shown as felt but shaking is not expected, send notification and stop notifying
                     } else if (homeShakingIntensity == 0 && maxHomeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
+                        maxHomeShakingIntensity = 0;
                         // otherwise, update the notification
                     } else if (homeShakingIntensity > 0) {
                         sendQuakeUpdateInfoEEW(event.earthquake());
@@ -88,12 +89,22 @@ public class PushNotificationPushover extends ListenerAdapter {
             GlobalQuake.instance.getEventHandler().registerEventListener(new GlobalQuakeEventListener() {
                 @Override
                 public void onQuakeCreate(QuakeCreateEvent event) {
-                    sendQuakeCreateInfo(event.earthquake());
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
+                    if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
+                        sendQuakeCreateInfo(event.earthquake());
+                        maxHomeShakingIntensity = 0; // Prevent sending no shaking expected notification
+                    }
                 }
 
                 @Override
                 public void onQuakeUpdate(QuakeUpdateEvent event) {
-                    sendQuakeUpdateInfo(event.earthquake());
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
+                    if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
+                        sendQuakeUpdateInfo(event.earthquake());
+                        maxHomeShakingIntensity = 0;
+                    }
                 }
 
                 @Override
@@ -103,7 +114,12 @@ public class PushNotificationPushover extends ListenerAdapter {
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    sendQuakeRemoveInfo(event.earthquake());
+                    homeShakingIntensity = determineHomeShakingIntensity(event.earthquake());
+                    // Do not send nearby Earthquake notification when user is already warned about felt shaking
+                    if (!(Settings.pushoverFeltShaking && homeShakingIntensity > 0)) {
+                        sendQuakeRemoveInfo(event.earthquake());
+                        maxHomeShakingIntensity = 0;
+                    }
                 }
             });
         }

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -51,13 +51,13 @@ public class PushNotificationPushover extends ListenerAdapter {
                     earthquakeList[currentEarthquake][1] = String.valueOf(determineHomeShakingIntensity(event.earthquake()));
                     earthquakeList[currentEarthquake][2] = earthquakeList[currentEarthquake][1];
 
-                    if (Settings.pushoverNearbyShaking && Settings.pushoverFeltShaking) {
+                    if ((Settings.pushoverNearbyShaking && Settings.pushoverSendRevisions) && Settings.pushoverFeltShaking) {
                         if (earthquakeList[currentEarthquake][1].equals("0")) {
                             sendQuakeCreateInfo(event.earthquake());
                         } else {
                             sendQuakeCreateInfoEEW(event.earthquake());
                         }
-                    } else if (Settings.pushoverNearbyShaking) {
+                    } else if (Settings.pushoverNearbyShaking && Settings.pushoverSendRevisions) {
                         sendQuakeCreateInfo(event.earthquake());
                     } else if (Settings.pushoverFeltShaking) {
                         if (!earthquakeList[currentEarthquake][1].equals("0")) {
@@ -72,13 +72,13 @@ public class PushNotificationPushover extends ListenerAdapter {
                         if (earthquakeList[i][0] != null && earthquakeList[i][0].equals(String.valueOf(event.earthquake().getUuid()))) {
                             earthquakeList[i][1] = String.valueOf(determineHomeShakingIntensity(event.earthquake()));
 
-                            if (Settings.pushoverNearbyShaking && Settings.pushoverFeltShaking) {
+                            if ((Settings.pushoverNearbyShaking && Settings.pushoverSendRevisions) && Settings.pushoverFeltShaking) {
                                 if (earthquakeList[currentEarthquake][1].equals("0") && earthquakeList[currentEarthquake][2].equals("0")) {
                                     sendQuakeUpdateInfo(event.earthquake());
                                 } else {
                                     determineType(event, i);
                                 }
-                            } else if (Settings.pushoverNearbyShaking) {
+                            } else if (Settings.pushoverNearbyShaking && Settings.pushoverSendRevisions) {
                                 sendQuakeUpdateInfo(event.earthquake());
                             } else if (Settings.pushoverFeltShaking) {
                                 determineType(event, i);
@@ -101,13 +101,13 @@ public class PushNotificationPushover extends ListenerAdapter {
                 public void onQuakeRemove(QuakeRemoveEvent event) {
                     for (int i = 0; i < 99; i++) {
                         if (earthquakeList[i][0] != null && earthquakeList[i][0].equals(String.valueOf(event.earthquake().getUuid()))) {
-                            if (Settings.pushoverNearbyShaking && Settings.pushoverFeltShaking) {
+                            if ((Settings.pushoverNearbyShaking && Settings.pushoverSendRevisions) && Settings.pushoverFeltShaking) {
                                 if (earthquakeList[currentEarthquake][1].equals("0") && earthquakeList[currentEarthquake][2].equals("0")) {
                                     sendQuakeRemoveInfo(event.earthquake());
                                 } else {
                                     sendQuakeRemoveInfoEEW(event.earthquake());
                                 }
-                            } else if (Settings.pushoverNearbyShaking) {
+                            } else if (Settings.pushoverNearbyShaking && Settings.pushoverSendRevisions) {
                                 sendQuakeRemoveInfo(event.earthquake());
                             } else if (Settings.pushoverFeltShaking) {
                                 if (!earthquakeList[currentEarthquake][1].equals("0")) {

--- a/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
+++ b/GlobalQuakeServer/src/main/java/gqserver/push_notification/PushNotificationPushover.java
@@ -74,7 +74,10 @@ public class PushNotificationPushover extends ListenerAdapter {
 
                 @Override
                 public void onQuakeRemove(QuakeRemoveEvent event) {
-                    sendQuakeRemoveInfoEEW(event.earthquake());
+                    // if user was warned about the earthquake, send a notification that the earthquake was cancelled
+                    if (maxHomeShakingIntensity > 0) {
+                        sendQuakeRemoveInfoEEW(event.earthquake());
+                    }
                     homeShakingIntensity = 0;
                     maxHomeShakingIntensity = 0;
                 }
@@ -146,7 +149,7 @@ public class PushNotificationPushover extends ListenerAdapter {
 
         String Title = "Revision #%d".formatted(earthquake.getRevisionID());
 
-        sendNotification(Title, createDescription(earthquake), 0, false, null);
+        sendNotification(Title, createDescription(earthquake), -1, false, null);
     }
 
     private static void sendQuakeUpdateInfoEEW(Earthquake earthquake) {
@@ -156,7 +159,7 @@ public class PushNotificationPushover extends ListenerAdapter {
 
         String Title = "";
         String customSound = "";
-        int priority = 2; // do not make an audible notification when revising, unless shaking intensity increased
+        int priority = -1; // do not make an audible notification when revising, unless shaking intensity increased
 
         if (homeShakingIntensity == 0) {
             Title = "No shaking is expected";
@@ -196,7 +199,7 @@ public class PushNotificationPushover extends ListenerAdapter {
         String Title = "Cancelled Earthquake";
         String message = "M%.1f %s".formatted(earthquake.getMag(), earthquake.getRegion());
 
-        sendNotification(Title, message, 0, false, null);
+        sendNotification(Title, message, Settings.pushoverNearbyShakingPriorityList, false, null);
     }
 
     private static void sendQuakeRemoveInfoEEW(Earthquake earthquake) {


### PR DESCRIPTION
GQServer is now capable of:
- Sending messages for earthquakes to the user's local and regional area
- Sending messages as EEW for any shaking at the user's home location (Untested)

Users can modify any setting in Settings->Alerts->Ntfy/Pushover:
- Modify the message priority for nearby earthquakes, light shaking, and strong shaking at their home location
- Use custom sounds for nearby earthquakes, light and strong shaking at their home location (Pushover only)
- Toggle whether they want to use Ntfy, Pushover, or both
- Toggle whether they want to get notified of nearby earthquakes, expected shaking, or both

Messages contain the same info as the discord bot + S-wave arrival and expected intensity at the user's home location

Credits for the original idea: @simulping